### PR TITLE
[WIP] Keep current buffer position consistent

### DIFF
--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -91,6 +91,7 @@ end
 
 -- FIXME this does not work if the same buffer is open in multiple window
 -- maybe do something with win_findbuf(bufnr('%'))
+-- see is we can get the containing window id for a buffer
 function M.Buffer:current()
   return vim.fn.winbufnr(0) == self.id
 end


### PR DESCRIPTION
When navigating backwards and forwards move the current buffer
along rather than shifting the other buffers around it which is
disconcerting. This PR shifts things so we move all the way across a "page" rather than "flowing" the other buffers around the current one.

### New:
![bufferline_navigation](https://user-images.githubusercontent.com/22454918/97119898-47b42700-170b-11eb-856a-19e66823fd7c.gif)

### Old:
![old_bufferline_navigation](https://user-images.githubusercontent.com/22454918/97120016-11c37280-170c-11eb-84fe-738b4af78429.gif)


NOTE: Currently it shifts the page when navigating past the penultimate buffer on the left or right which is a little bit intuitive but this is generally an improvement.