### PR TITLE
Persist user sorted buffer positions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ all of it's functionality though.
 
 ![move current buffer](./screenshots/re-order.gif "Move current buffer")
 
+This order can be persisted between sessions (enabled by default).
+
 #### Modified symbol
 
 <img src="./screenshots/bufferline_with_modified.png" alt="modified icon" width="350px" />
@@ -92,6 +94,10 @@ nnoremap <silent>b] :BufferLineCyclePrev<CR>
 nnoremap <silent><mymap> :BufferLineMoveNext<CR>
 nnoremap <silent><mymap> :BufferLineMovePrev<CR>
 ```
+
+If you manually arrange your buffers using `:BufferLineMove{Prev/Next}` during an nvim session this can be persisted for the session.
+This is enabled by default but you need to ensure that your `sessionopts+=globals` otherwise the session file will
+not track global variables which is the mechanism used to store your sort order.
 
 ## Warning
 
@@ -154,6 +160,7 @@ require'bufferline'.setup{
     max_prefix_length = 15, -- prefix used when a buffer is deduplicated
     tab_size = 18,
     show_buffer_close_icons = true | false,
+    persist_buffer_sort = true, -- whether or not custom sorted buffers should persist
     -- can also be a table containing 2 custom separators
     -- [focused and unfocused]. eg: { '|', '|' }
     separator_style = "slant" | "thick" | "thin" | { 'any', 'any' },

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -23,6 +23,16 @@ local strwidth = vim.fn.strwidth
 local padding = constants.padding
 local separator_styles = constants.separator_styles
 
+
+local function save_positions(buffers)
+  return table.concat(buffers, ',')
+end
+
+local function restore_positions()
+  local str = vim.g.Bufferline_positions
+  if not str then return str end
+  return vim.split(str, ',')
+end
 -----------------------------------------------------------
 -- State
 -----------------------------------------------------------
@@ -554,9 +564,9 @@ end
 
 --- TODO can this be done more efficiently in one loop?
 --- @param buf_nums table<number>
---- @param sorted table<number>
-local function get_updated_buffers(buf_nums, sorted)
-  if not state.custom_sort then
+local function get_updated_buffers(buf_nums)
+  local sorted = state.custom_sort or restore_positions()
+  if not sorted then
     return buf_nums
   end
   local updated = {}
@@ -581,7 +591,7 @@ end
 local function bufferline(preferences)
   local options = preferences.options
   local buf_nums = get_buffers_by_mode(options.view)
-  buf_nums = get_updated_buffers(buf_nums, state.custom_sort)
+  buf_nums = get_updated_buffers(buf_nums)
   local all_tabs = tabs.get(options.separator_style, preferences)
 
   if not options.always_show_bufferline then

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -46,6 +46,7 @@ function M.get_defaults()
       show_buffer_close_icons = true,
       enforce_regular_tabs = false,
       always_show_bufferline = true,
+      persist_buffer_sort = true,
       max_prefix_length = 15,
       sort_by = "default"
     },

--- a/lua/bufferline/constants.lua
+++ b/lua/bufferline/constants.lua
@@ -10,4 +10,6 @@ M.separator_styles = {
   thin = "thin"
 }
 
+M.positions_key = 'BufferlinePositions'
+
 return M

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -86,11 +86,8 @@ function M.make_clickable(context)
   end
   -- v:lua does not support function references in vimscript so
   -- the only way to implement this is using autoload viml functions
-  if mode == "multiwindow" then
-    return "%" .. buf_num .. "@nvim_bufferline#handle_win_click@" .. component
-  else
-    return "%" .. buf_num .. "@nvim_bufferline#handle_click@" .. component
-  end
+  local fn =  mode == "multiwindow" and "handle_win_click" or "handle_click"
+  return "%" .. buf_num .. "@nvim_bufferline#"..fn.."@" .. component
 end
 
 -- The provided api nvim_is_buf_loaded filters out all hidden buffers


### PR DESCRIPTION
This change allows a new default whereby if a user sorts buffers into specific positions we maintain the sort order, using `vim.g.variables`. This will require a user to have `sessionopts+=globals` set so session files persist `g` values