### PR TITLE
Improve highlight naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,37 +244,101 @@ nnoremap mymap :lua require"bufferline".go_to_buffer(num)<CR>
 This plugin is designed to work automatically, deriving colours from the user's theme,
 but if you must...
 
+Keep in mind that despite my best efforts not to change these they might require the occasional
+tweak (if you don't customise these too much you should be fine 🤞). If you do, you might need
+to tweak these occasionally, the plugin will emit a warning if any of the groups you specify don't
+exist
+
 ```vim
 lua require'bufferline'.setup{
   highlights = {
-    tab = {
-      guifg = comment_fg,
-      guibg = normal_bg,
+      fill = {
+        guifg = comment_fg,
+        guibg = separator_background_color
+      },
+      background = {
+        guifg = comment_fg,
+        guibg = background_color
+      },
+      tab = {
+        guifg = comment_fg,
+        guibg = background_color
+      },
+      tab_selected = {
+        guifg = tabline_sel_bg,
+        guibg = normal_bg
+      },
+      tab_close = {
+        guifg = comment_fg,
+        guibg = background_color
+      },
+      buffer_visible = {
+        guifg = comment_fg,
+        guibg = visible_bg
+      },
+      buffer_selected = {
+        guifg = normal_fg,
+        guibg = normal_bg,
+        gui = "bold,italic"
+      },
+      modified = {
+        guifg = string_fg,
+        guibg = background_color
+      },
+      modified_visible = {
+        guifg = string_fg,
+        guibg = visible_bg
+      },
+      modified_selected = {
+        guifg = string_fg,
+        guibg = normal_bg
+      },
+      duplicate_selected = {
+        guifg = duplicate_color,
+        gui = "italic",
+        guibg = normal_bg
+      },
+      duplicate_visible = {
+        guifg = duplicate_color,
+        gui = "italic",
+        guibg = visible_bg
+      },
+      duplicate = {
+        guifg = duplicate_color,
+        gui = "italic",
+        guibg = background_color
+      },
+      separator_selected = {
+        guifg = separator_background_color,
+        guibg = normal_bg
+      },
+      separator_visible = {
+        guifg = separator_background_color,
+        guibg = visible_bg
+      },
+      separator = {
+        guifg = separator_background_color,
+        guibg = background_color
+      },
+      indicator_selected = {
+        guifg = tabline_sel_bg,
+        guibg = normal_bg
+      },
+      pick_selected = {
+        guifg = error_fg,
+        guibg = normal_bg,
+        gui = "bold,italic"
+      },
+      pick_visible = {
+        guifg = error_fg,
+        guibg = visible_bg,
+        gui = "bold,italic"
+      },
+      pick = {
+        guifg = error_fg,
+        guibg = background_color,
+        gui = "bold,italic"
+      }
     };
-    tab_selected = {
-      guifg = comment_fg,
-      guibg = tabline_sel_bg,
-    };
-    buffer = {
-      guifg = comment_fg,
-      guibg = custom_bg,
-    };
-    buffer_inactive = {
-      guifg = comment_fg,
-      guibg = normal_bg,
-    };
-    modified = {
-      guifg = diff_add_fg,
-      guibg = "none"
-    };
-    separator = {
-      guibg = custom_bg,
-    };
-    selected = {
-      guifg = normal_fg,
-      guibg = normal_bg,
-      gui = "bold,italic",
-    };
-  };
 }
 ```

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -107,7 +107,6 @@ local function get_buffer_highlight(buffer, highlights)
     hl.duplicate = h.duplicate.hl
     hl.pick = h.pick.hl
     hl.separator = h.selected_separator.hl
-    hl.buffer = h.selected
   elseif buffer:visible() then
     hl.background = h.buffer_inactive.hl
     hl.modified = h.modified_inactive.hl
@@ -121,7 +120,6 @@ local function get_buffer_highlight(buffer, highlights)
     hl.duplicate = h.duplicate_inactive.hl
     hl.pick = h.pick_inactive.hl
     hl.separator = h.separator.hl
-    hl.buffer = h.background
   end
   return hl
 end

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -102,24 +102,24 @@ local function get_buffer_highlight(buffer, highlights)
   local hl = {}
   local h = highlights
   if buffer:current() then
-    hl.background = h.selected.hl
+    hl.background = h.buffer_selected.hl
     hl.modified = h.modified_selected.hl
-    hl.duplicate = h.duplicate.hl
-    hl.pick = h.pick.hl
-    hl.separator = h.selected_separator.hl
-    hl.buffer = h.selected
+    hl.duplicate = h.duplicate_selected.hl
+    hl.pick = h.pick_selected.hl
+    hl.separator = h.separator_selected.hl
+    hl.buffer = h.buffer_selected
   elseif buffer:visible() then
-    hl.background = h.buffer_inactive.hl
-    hl.modified = h.modified_inactive.hl
-    hl.duplicate = h.duplicate.hl
-    hl.pick = h.pick_inactive.hl
-    hl.separator = h.separator_inactive.hl
-    hl.buffer = h.buffer_inactive
+    hl.background = h.buffer_visible.hl
+    hl.modified = h.modified_visible.hl
+    hl.duplicate = h.duplicate_visible.hl
+    hl.pick = h.pick_visible.hl
+    hl.separator = h.separator_visible.hl
+    hl.buffer = h.buffer_visible
   else
     hl.background = h.background.hl
     hl.modified = h.modified.hl
-    hl.duplicate = h.duplicate_inactive.hl
-    hl.pick = h.pick_inactive.hl
+    hl.duplicate = h.duplicate.hl
+    hl.pick = h.pick.hl
     hl.separator = h.separator.hl
     hl.buffer = h.background
   end
@@ -250,7 +250,7 @@ local function indicator_component(context)
       -- background highlight doesn't appear in th middle
       -- alternatives:  right aligned => ▕ ▐ ,  left aligned => ▍
       symbol = "▎"
-      indicator = hl.selected_indicator.hl .. symbol .. "%*"
+      indicator = hl.indicator_selected.hl .. symbol .. "%*"
     end
     length = length + strwidth(symbol)
     component = indicator .. curr_hl.background .. component

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -784,9 +784,33 @@ local function setup_autocommands(preferences)
   utils.nvim_create_augroups({BufferlineColors = autocommands})
 end
 
+local function validate_prefs(prefs, defaults)
+  if prefs.highlights then
+    local incorrect = {}
+    for k, _ in pairs(prefs.highlights) do
+      if not defaults.highlights[k] then
+        table.insert(incorrect, k)
+      end
+    end
+    local is_plural = #incorrect > 1
+    local verb = is_plural and " are " or " is "
+    local article = is_plural and " " or " a "
+    local object = is_plural and " groups. " or " group. "
+    local msg =
+      table.concat(incorrect, ", ") ..
+      verb ..
+        "not" ..
+          article ..
+            "valid highlight" ..
+              object .. "Please check the README for all valid highlights"
+    utils.echomsg(msg, "WarningMsg")
+  end
+end
+
 -- TODO then validate user preferences and only set prefs that exists
 function M.setup(prefs)
   local preferences = config.get_defaults()
+  validate_prefs(prefs, preferences)
   -- Combine user preferences with defaults preferring the user's own settings
   if prefs and type(prefs) == "table" then
     preferences = vim.tbl_deep_extend("force", preferences, prefs)

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -107,6 +107,7 @@ local function get_buffer_highlight(buffer, highlights)
     hl.duplicate = h.duplicate.hl
     hl.pick = h.pick.hl
     hl.separator = h.selected_separator.hl
+    hl.buffer = h.selected
   elseif buffer:visible() then
     hl.background = h.buffer_inactive.hl
     hl.modified = h.modified_inactive.hl
@@ -120,6 +121,7 @@ local function get_buffer_highlight(buffer, highlights)
     hl.duplicate = h.duplicate_inactive.hl
     hl.pick = h.pick_inactive.hl
     hl.separator = h.separator.hl
+    hl.buffer = h.background
   end
   return hl
 end

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -24,7 +24,7 @@ function M.get_defaults()
   local separator_shading = is_bright_background and -20 or -45
   local background_shading = is_bright_background and -12 or -25
 
-  local inactive_bg = colors.shade_color(normal_bg, -8)
+  local visible_bg = colors.shade_color(normal_bg, -8)
   local duplicate_color = colors.shade_color(comment_fg, -5)
   local separator_background_color =
     colors.shade_color(normal_bg, separator_shading)
@@ -72,27 +72,32 @@ function M.get_defaults()
         guifg = comment_fg,
         guibg = background_color
       },
-      buffer_inactive = {
+      buffer_visible = {
         guifg = comment_fg,
-        guibg = inactive_bg
+        guibg = visible_bg
       },
       modified = {
         guifg = string_fg,
         guibg = background_color
       },
-      duplicate = {
+      duplicate_selected = {
         guifg = duplicate_color,
         gui = "italic",
         guibg = normal_bg
       },
-      duplicate_inactive = {
+      duplicate_visible = {
+        guifg = duplicate_color,
+        gui = "italic",
+        guibg = visible_bg
+      },
+      duplicate = {
         guifg = duplicate_color,
         gui = "italic",
         guibg = background_color
       },
-      modified_inactive = {
+      modified_visible = {
         guifg = string_fg,
-        guibg = inactive_bg
+        guibg = visible_bg
       },
       modified_selected = {
         guifg = string_fg,
@@ -102,19 +107,19 @@ function M.get_defaults()
         guifg = separator_background_color,
         guibg = background_color
       },
-      separator_inactive = {
+      separator_visible = {
         guifg = separator_background_color,
-        guibg = inactive_bg
+        guibg = visible_bg
       },
-      selected_separator = {
+      separator_selected = {
         guifg = separator_background_color,
         guibg = normal_bg
       },
-      selected_indicator = {
+      indicator_selected = {
         guifg = tabline_sel_bg,
         guibg = normal_bg
       },
-      selected = {
+      buffer_selected = {
         guifg = normal_fg,
         guibg = normal_bg,
         gui = "bold,italic"
@@ -124,7 +129,12 @@ function M.get_defaults()
         guibg = normal_bg,
         gui = "bold,italic"
       },
-      pick_inactive = {
+      pick_selected = {
+        guifg = error_fg,
+        guibg = normal_bg,
+        gui = "bold,italic"
+      },
+      pick_visible = {
         guifg = error_fg,
         guibg = background_color,
         gui = "bold,italic"

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -52,6 +52,14 @@ function M.get_defaults()
       sort_by = "default"
     },
     highlights = {
+      fill = {
+        guifg = comment_fg,
+        guibg = separator_background_color
+      },
+      background = {
+        guifg = comment_fg,
+        guibg = background_color
+      },
       tab = {
         guifg = comment_fg,
         guibg = background_color
@@ -64,21 +72,26 @@ function M.get_defaults()
         guifg = comment_fg,
         guibg = background_color
       },
-      fill = {
-        guifg = comment_fg,
-        guibg = separator_background_color
-      },
-      background = {
-        guifg = comment_fg,
-        guibg = background_color
-      },
       buffer_visible = {
         guifg = comment_fg,
         guibg = visible_bg
       },
+      buffer_selected = {
+        guifg = normal_fg,
+        guibg = normal_bg,
+        gui = "bold,italic"
+      },
       modified = {
         guifg = string_fg,
         guibg = background_color
+      },
+      modified_visible = {
+        guifg = string_fg,
+        guibg = visible_bg
+      },
+      modified_selected = {
+        guifg = string_fg,
+        guibg = normal_bg
       },
       duplicate_selected = {
         guifg = duplicate_color,
@@ -95,39 +108,21 @@ function M.get_defaults()
         gui = "italic",
         guibg = background_color
       },
-      modified_visible = {
-        guifg = string_fg,
-        guibg = visible_bg
-      },
-      modified_selected = {
-        guifg = string_fg,
-        guibg = normal_bg
-      },
-      separator = {
+      separator_selected = {
         guifg = separator_background_color,
-        guibg = background_color
+        guibg = normal_bg
       },
       separator_visible = {
         guifg = separator_background_color,
         guibg = visible_bg
       },
-      separator_selected = {
+      separator = {
         guifg = separator_background_color,
-        guibg = normal_bg
+        guibg = background_color
       },
       indicator_selected = {
         guifg = tabline_sel_bg,
         guibg = normal_bg
-      },
-      buffer_selected = {
-        guifg = normal_fg,
-        guibg = normal_bg,
-        gui = "bold,italic"
-      },
-      pick = {
-        guifg = error_fg,
-        guibg = background_color,
-        gui = "bold,italic"
       },
       pick_selected = {
         guifg = error_fg,
@@ -137,6 +132,11 @@ function M.get_defaults()
       pick_visible = {
         guifg = error_fg,
         guibg = visible_bg,
+        gui = "bold,italic"
+      },
+      pick = {
+        guifg = error_fg,
+        guibg = background_color,
         gui = "bold,italic"
       }
     }

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -126,7 +126,7 @@ function M.get_defaults()
       },
       pick = {
         guifg = error_fg,
-        guibg = normal_bg,
+        guibg = background_color,
         gui = "bold,italic"
       },
       pick_selected = {
@@ -136,7 +136,7 @@ function M.get_defaults()
       },
       pick_visible = {
         guifg = error_fg,
-        guibg = background_color,
+        guibg = visible_bg,
         gui = "bold,italic"
       }
     }

--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -8,14 +8,11 @@ local function hl(item)
   return "%#" .. item .. "#"
 end
 
-local function hl_exists(name)
+function M.hl_exists(name)
   return vim.fn.hlexists(name) > 0
 end
 
 function M.set_one(name, hl)
-  if hl_exists(name) then
-    return
-  end
   if hl and vim.tbl_count(hl) > 0 then
     local cmd = "highlight! " .. name
     if hl.gui and hl.gui ~= "" then

--- a/lua/bufferline/tabs.lua
+++ b/lua/bufferline/tabs.lua
@@ -12,7 +12,7 @@ end
 local function render(tab, is_active, style, highlights)
   local h = highlights
   local hl = is_active and h.tab_selected.hl or h.tab.hl
-  local separator_hl = is_active and h.selected_separator.hl or h.separator.hl
+  local separator_hl = is_active and h.separator_selected.hl or h.separator.hl
   local separator_component = style == "thick" and "▐" or "▕"
   local separator = separator_hl .. separator_component
   local name = padding .. padding .. tab.tabnr .. padding

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -75,8 +75,8 @@ function M.make_clickable(context)
   end
   -- v:lua does not support function references in vimscript so
   -- the only way to implement this is using autoload viml functions
-  local fn =  mode == "multiwindow" and "handle_win_click" or "handle_click"
-  return "%" .. buf_num .. "@nvim_bufferline#"..fn.."@" .. component
+  local fn = mode == "multiwindow" and "handle_win_click" or "handle_click"
+  return "%" .. buf_num .. "@nvim_bufferline#" .. fn .. "@" .. component
 end
 
 -- The provided api nvim_is_buf_loaded filters out all hidden buffers
@@ -109,6 +109,13 @@ end
 
 function M.echoerr(msg)
   vim.cmd(string.format([[echoerr "%s"]], msg))
+end
+
+function M.echomsg(msg, hl)
+  hl = hl or "Title"
+  vim.cmd("echohl " .. hl)
+  vim.cmd(string.format([[echomsg "[nvim-bufferline] %s"]], msg))
+  vim.cmd("echohl none")
 end
 
 return M


### PR DESCRIPTION
Highlights are inconsistently named making working with them quite confusing. This PR refactors the naming so it is clearer and more consistent e.g. {item}_{status}, `buffer_visible` etc. It isn't a backward compatible change but I've added in the first part of config validation which checks if a user has any keys in their highlight fields that aren't in the default config aka it is invalid if so we print a message to warn them.

Hopefully people can then check the README to update them