### PR TITLE
fix nil prefs error

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -785,7 +785,7 @@ local function setup_autocommands(preferences)
 end
 
 local function validate_prefs(prefs, defaults)
-  if prefs.highlights then
+  if prefs ~= nil and prefs.highlights then
     local incorrect = {}
     for k, _ in pairs(prefs.highlights) do
       if not defaults.highlights[k] then


### PR DESCRIPTION
Recent changes is breaking the plugin for me, the i realized that part was not handling a possible nil prefs obj. That fixed the issue on my side, not sure if its also just something on my side or an actual bug.

My configs are not using any custom prefs in `require('bufferline').setup()` .