### PR TITLE
Add functionality to filter buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,9 @@ require'bufferline'.setup{
     sort_by = 'extension' | 'relative_directory' | 'directory' | function(buffer_a, buffer_b)
       -- add custom logic
       return buffer_a.modified > buffer_b.modified
+    end,
+    filter = function(buffer_id)
+      -- add custom logic, or return `nil` to use the default
     end
   }
 }
@@ -207,6 +210,38 @@ end
 When using a sorted bufferline it's advisable that you use the `BufferLineCycleNext` and `BufferLineCyclePrev`
 commands since these will traverse the bufferline bufferlist in order whereas `bnext` and `bprev` will cycle
 buffers according to the buffer numbers given by vim.
+
+### Filtering Buffers
+
+Bufferline allows you to specify a function to filter what buffers are visible at any given time.
+This function is called for each buffer and can return 1 of three values:
+
+- `true` - Meaning the buffer should be shown
+- `false` - Meaning the buffer should be hidden
+- `nil` - Meaning the buffer should use it's default visibility
+
+In the following example, the filtering changes depending on if the current tab has the `t:is_help_tab`
+option set to a truthy value. If it is set to anything else or does not exist, it returns `nil`. Then, it gets
+the `buftype` of the given `buffer_id` and returns `true` if it is a help buffer. This allows for the ability to
+have a separate tab for showing open help buffers, and the ability to switch between them like other buffers.
+
+```lua
+filter = function(buffer_id)
+  -- add custom logic
+  if not vim.t.is_help_tab then
+    return nil -- Use the buffer's default visibility
+  end
+  local buftype = vim.api.nvim_buf_get_option(buf_num, "buftype")
+  return buftype == "help" -- Only show help buffers
+end
+```
+
+![Buffer filtering](./screenshots/filtering.gif "Buffer Filtering functionality")
+
+Another possibility for filtering is using tabs to separate buffers into projects by checking
+if the value of a given `t:` variable exists in each buffer's path, etc.
+
+> Side note: Currently this functionality is disabled when the `view` option is set to `multiwindow`.
 
 ### Bufferline Pick functionality (inspired by [`barbar.nvim`](https://github.com/romgrk/barbar.nvim))
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -158,7 +158,7 @@ local function get_buffers_by_mode(mode)
       return utils.get_valid_buffers(unique)
     end
   end
-  return utils.get_valid_buffers()
+  return utils.get_valid_buffers(nil, state.preferences.options.filter)
 end
 
 local function truncate_filename(filename, word_limit)

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -49,7 +49,8 @@ function M.get_defaults()
       always_show_bufferline = true,
       persist_buffer_sort = true,
       max_prefix_length = 15,
-      sort_by = "default"
+      sort_by = "default",
+      filter = function(buf_num) end
     },
     highlights = {
       fill = {

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -90,16 +90,21 @@ function M.is_valid(buf_num)
 end
 
 --- @param bufs table | nil
-function M.get_valid_buffers(bufs)
+function M.get_valid_buffers(bufs, filter)
   local buf_nums = bufs or vim.api.nvim_list_bufs()
   local valid_bufs = {}
+  filter = filter or M.is_valid
 
   -- NOTE: In lua in order to iterate an array, indices should
   -- not contain gaps otherwise "ipairs" will stop at the first gap
   -- i.e the indices should be contiguous
   local count = 0
   for _, buf in ipairs(buf_nums) do
-    if M.is_valid(buf) then
+    local is_valid = filter(buf)
+    if is_valid == nil then
+      is_valid = M.is_valid(buf)
+    end
+    if is_valid then
       count = count + 1
       valid_bufs[count] = buf
     end


### PR DESCRIPTION
This PR adds functionality to filter what buffers are visible using a function that the user can specify in their options. 

This function runs for each buffer that is open. It currently takes in the buffer's ID as a parameter, but looking at the sort function, perhaps a reference to the buffer itself could be better. The user is able to specify a return value of `true`, `false` or `nil` to set the visibility (`nil` uses the default visibility).

Here is an example of how this feature can be used:
![image](https://user-images.githubusercontent.com/21961037/103880722-5f564700-508e-11eb-8bc0-c591bdd9e81d.png)
Here is the same instance vim instance after pressing `gt`
![image](https://user-images.githubusercontent.com/21961037/103880735-63826480-508e-11eb-832a-4edd97f952f5.png)

Currently this feature does not apply when the user has their `view` option set to `multiwindow`.

TODO:

- [x] Add basic filtering method
- [x] Allow the user to override the default method in their options
- [x] Add documentation for filtering buffers to the README
- [x] Add a gif of the feature being used

TO-POSSIBLY-DO

- [ ] Redo the example gif so that it uses the same esthetics as the existing gifs
- [ ] Add ability to have multiple filtering methods
	- [ ] Add separate function used to determine which filtering method to use
