### PR TITLE
Fix rendering problem of file icons in Windows Terminal

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -282,8 +282,8 @@ local function add_prefix(context)
   local length = context.length
 
   if state.is_picking and buffer.letter then
-    component = hl.pick .. buffer.letter .. hl.background .. component
-    length = length + strwidth(buffer.letter)
+    component = hl.pick .. buffer.letter .. padding .. hl.background .. component
+    length = length + strwidth(buffer.letter) + strwidth(padding)
   elseif buffer.icon then
     local icon_highlight = highlight_icon(buffer, hl.buffer)
     component = icon_highlight .. hl.background .. component

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -210,7 +210,7 @@ local function highlight_icon(buffer, background)
     local guifg = colors.get_hex(hl, "fg")
     highlights.set_one(new_hl, {guibg = background.guibg, guifg = guifg})
   end
-  return "%#" .. new_hl .. "#" .. icon .. "%*"
+  return "%#" .. new_hl .. "#" .. icon .. " %*"
 end
 
 --- "▍" "░"
@@ -280,7 +280,6 @@ local function add_prefix(context)
   local buffer = context.buffer
   local hl = context.current_highlights
   local length = context.length
-
   if state.is_picking and buffer.letter then
     component = hl.pick .. buffer.letter .. padding .. hl.background .. component
     length = length + strwidth(buffer.letter) + strwidth(padding)

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -210,7 +210,7 @@ local function highlight_icon(buffer, background)
     local guifg = colors.get_hex(hl, "fg")
     highlights.set_one(new_hl, {guibg = background.guibg, guifg = guifg})
   end
-  return "%#" .. new_hl .. "#" .. icon .. " %*"
+  return "%#" .. new_hl .. "#" .. icon .. padding .. "%*"
 end
 
 --- "▍" "░"

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -280,13 +280,14 @@ local function add_prefix(context)
   local buffer = context.buffer
   local hl = context.current_highlights
   local length = context.length
+
   if state.is_picking and buffer.letter then
     component = hl.pick .. buffer.letter .. padding .. hl.background .. component
     length = length + strwidth(buffer.letter) + strwidth(padding)
   elseif buffer.icon then
     local icon_highlight = highlight_icon(buffer, hl.buffer)
     component = icon_highlight .. hl.background .. component
-    length = length + strwidth(buffer.icon)
+    length = length + strwidth(buffer.icon .. padding)
   end
   return component, length
 end

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -81,11 +81,9 @@ function M.Buffer:new(buf)
     if lua_devicons_loaded then
       buf.icon, buf.icon_highlight =
         webdev_icons.get_icon(buf.path, buf.extension, {default = true})
-      buf.icon = buf.icon .. ' '
     else
       local devicons_loaded = fn.exists("*WebDevIconsGetFileTypeSymbol") > 0
       buf.icon = devicons_loaded and fn.WebDevIconsGetFileTypeSymbol(buf.path) or ""
-      buf.icon = buf.icon .. ' '
     end
     -- TODO: allow the format specifier to be configured
     buf.filename = (buf.path and #buf.path > 0) and fn.fnamemodify(buf.path, ":p:t") or "[No Name]"

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -81,9 +81,11 @@ function M.Buffer:new(buf)
     if lua_devicons_loaded then
       buf.icon, buf.icon_highlight =
         webdev_icons.get_icon(buf.path, buf.extension, {default = true})
+      buf.icon = buf.icon .. ' '
     else
       local devicons_loaded = fn.exists("*WebDevIconsGetFileTypeSymbol") > 0
       buf.icon = devicons_loaded and fn.WebDevIconsGetFileTypeSymbol(buf.path) or ""
+      buf.icon = buf.icon .. ' '
     end
     -- TODO: allow the format specifier to be configured
     buf.filename = (buf.path and #buf.path > 0) and fn.fnamemodify(buf.path, ":p:t") or "[No Name]"

--- a/lua/bufferline/duplicates.lua
+++ b/lua/bufferline/duplicates.lua
@@ -112,11 +112,8 @@ function M.component(context)
         return truncate(dir, depth, options.max_prefix_length)
       end
     )
-    component = padding .. hl.duplicate .. dir .. hl.background .. component
-    length = length + strwidth(padding .. dir)
-  else
-    component = padding .. component
-    length = length + strwidth(padding)
+    component = hl.duplicate .. dir .. hl.background .. component
+    length = length + strwidth(dir)
   end
   return component, length
 end


### PR DESCRIPTION
In Windows Terminal, file's icon shows only left part when the buffer is selected. I print the string of the tabline,  finding that the icon's right half is override by other characters.  (The icon I use is two characters width.)  So I make the following changes:
  1. Move the white space right before the filename to the position right
     after the icon.
  2. Insert a white space between the letter when BufferLinePick called.

I use it in both Windows Terminal and vscode's terminal and both work properly.