### PR TITLE
Fix nvim-web-devicons initialization

### DIFF
--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -1,7 +1,4 @@
 local lua_devicons_loaded, webdev_icons = pcall(require, "nvim-web-devicons")
-if lua_devicons_loaded then
-  webdev_icons.setup()
-end
 
 local utils = require "bufferline/utils"
 local fn = vim.fn


### PR DESCRIPTION
It looks like initialization of `nvim-web-devicons` is not necessary. Telescope / Lualine also does not initialize `nvim-web-dewicons` manually. Fixes icon colors for me. References #46. Could you please check if this fix breaks icons for you?