### PR TITLE
Add ability to specify color highlight names

### DIFF
--- a/doc/bufferline-lua.txt
+++ b/doc/bufferline-lua.txt
@@ -194,6 +194,25 @@ Keep in mind that despite my best efforts not to change these they might
 require the occasional tweak (if you don't customise these too much you should
 be fine 🤞).
 
+Highlight values can also be specified as tables with a key of the highlight
+name e.g. `Normal` and the attribute which is one of `fg`, `bg`. See the
+`{what}` argument of `:h synIDAttr` for details, but only these 2 have been
+tested
+
+for example: >
+    highlights = {
+        fill = {
+            guibg = {
+                attribute = "fg",
+                highlight = "Pmenu"
+            }
+        }
+    }
+<
+This will automatically pull the value of `Pmenu` fg color and use it
+Any improperly specified tables will be set to `nil` and overriden with the
+default value for that key. 
+
 NOTE: you can specify colors the same way you specify `gui` colors for the
 highlight command. See `:h highlight` .
     >

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -834,6 +834,9 @@ end
 --- Convert highlights specified as tables to the correct existing colours
 ---@param prefs table
 local function convert_hl_tables(prefs)
+  if not prefs.highlights or vim.tbl_isempty(prefs.highlights) then
+    return
+  end
   for hl, attributes in pairs(prefs.highlights) do
     for attribute, value in pairs(attributes) do
       if type(value) == "table" then

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -816,18 +816,42 @@ local function validate_prefs(prefs, defaults)
     local article = is_plural and " " or " a "
     local object = is_plural and " groups. " or " group. "
     local msg =
-      table.concat(incorrect, ", ") ..
-      verb ..
-        "not" ..
-          article ..
-            "valid highlight" .. object .. "Please check the README for all valid highlights"
+      table.concat(
+      {
+        table.concat(incorrect, ", "),
+        verb,
+        "not",
+        article,
+        "valid highlight",
+        object,
+        "Please check the README for all valid highlights"
+      }
+    )
     utils.echomsg(msg, "WarningMsg")
+  end
+end
+
+--- Convert highlights specified as tables to the correct existing colours
+---@param prefs table
+local function convert_hl_tables(prefs)
+  for hl, attributes in pairs(prefs.highlights) do
+    for attribute, value in pairs(attributes) do
+      if type(value) == "table" then
+        if value.highlight and value.attribute then
+          prefs.highlights[hl][attribute] = colors.get_hex(value.highlight, value.attribute)
+        else
+          prefs.highlights[hl][attribute] = nil
+          print(string.format("removing %s as it is not formatted correctly", hl))
+        end
+      end
+    end
   end
 end
 
 local function merge_preferences(prefs)
   local preferences = config.get_defaults()
   validate_prefs(prefs, preferences)
+  convert_hl_tables(prefs)
   -- Combine user preferences with defaults preferring the user's own settings
   if prefs and type(prefs) == "table" then
     preferences = vim.tbl_deep_extend("force", preferences, prefs)


### PR DESCRIPTION
This PR adds the ability for users to specify colors using the `highlight` name and the part of the highlight to use. for example:
```lua
  require("bufferline").setup {
    highlights = {
      buffer_selected = {
        guifg = {highlight = "ErrorMsg", attribute = "fg"},
      },
    }
  }
```
This will use `synIDAttr` and `hlID` to find the value of the `ErrorMsg`'s `fg` color and set the guifg to that value