### PR TITLE
Allow users to specify a custom filter function

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,22 @@ require'bufferline'.setup{
     diagnostics_indicator = function(count, level)
       return "("..count..")"
     end
+    -- NOTE: this will be called a lot so don't do any heavy processing here
+    custom_filter = function(buf_number)
+      -- filter out filetypes you don't want to see
+      if vim.bo[buf_number].filetype ~= "<i-dont-want-to-see-this>" then
+        return true
+      end
+      -- filter out by buffer name
+      if vim.fn.bufname(buf_number) ~= "<buffer-name-I-dont-want>" then
+        return true
+      end
+      -- filter out based on arbitrary rules
+      -- e.g. filter out vim wiki buffer from tabline in your work repo
+      if vim.fn.getcwd() == "<work-repo>" and vim.bo[buf_number].filetype ~= "wiki" then
+        return true
+      end
+    end,
     show_buffer_close_icons = true | false,
     show_close_icon = true | false,
     show_tab_indicators = true | false,

--- a/doc/bufferline-lua.txt
+++ b/doc/bufferline-lua.txt
@@ -166,9 +166,9 @@ FILTERING                                           *bufferline-lua-filtering*
 
 Bufferline can be configured to take a custom filtering function via the
 `custom_filter` option. This value must be a lua function that will receive
-each buffer num that is going to be used for the bufferline. A user can then
+each buffer number that is going to be used for the bufferline. A user can then
 check whatever they would like and return `true` if they would like it to
-appear and false if not. 
+appear and `false` if not. 
 For example: >
     custom_filter = function(buf)
         -- dont show help buffers in the bufferline

--- a/doc/bufferline-lua.txt
+++ b/doc/bufferline-lua.txt
@@ -13,6 +13,7 @@ Usage..................................: |bufferline-lua-usage|
 Settings...............................: |bufferline-lua-settings|
 LSP Diagnostics........................: |bufferline-lua-diagnostics|
 Sorting................................: |bufferline-lua-sorting|
+Filtering..............................: |bufferline-lua-filtering|
 Pick...................................: |bufferline-lua-pick|
 Multi-window...........................: |bufferline-lua-multiwindow|
 Mappings...............................: |bufferline-lua-mapping|
@@ -160,6 +161,43 @@ When using a sorted bufferline it's advisable that you use the
 traverse the bufferline bufferlist in order whereas `bnext` and `bprev` will
 cycle buffers according to the buffer numbers given by vim.
 
+==============================================================================
+FILTERING                                           *bufferline-lua-filtering*
+
+Bufferline can be configured to take a custom filtering function via the
+`custom_filter` option. This value must be a lua function that will receive
+each buffer num that is going to be used for the bufferline. A user can then
+check whatever they would like and return `true` if they would like it to
+appear and false if not. 
+For example: >
+    custom_filter = function(buf)
+        -- dont show help buffers in the bufferline
+        return not vim.bo[buf].filetype == "help" then
+
+        -- you can use more custom logic for example
+        -- don't show files matching a pattern
+        return not vim.fn.bufname(buf):match('test')
+
+        -- show only certain filetypes in certain tabs e.g. js in one, css in
+        another etc.
+        local tab_num = vim.fn.tabpagenr()
+        if tab_num == 1 and vim.bo[buf].filetype == "javascript" then
+            return true
+        elseif tab_num == 2 and vim.bo[buf].filetype == "css" then
+            return true
+        else
+            return false
+        end
+
+
+        -- my personal example, don't show output log buffers in the
+        -- same tab as my other code
+        local tab_num = vim.fn.tabpagenr()
+        local is_log = vim.bo[buf].filetype == "log"
+        -- only show log buffers in secondary tabs
+        return (tab_num == 1 and not is_log) or (tab_num > 1 and is_log)
+    end
+<
 ==============================================================================
 BUFFERLINE PICK                                            *bufferline-lua-pick*
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -11,7 +11,9 @@ local config = require "bufferline/config"
 local tabs = require "bufferline/tabs"
 local buffers = require "bufferline/buffers"
 
+---@type Buffer
 local Buffer = buffers.Buffer
+---@type Buffers
 local Buffers = buffers.Buffers
 
 local api = vim.api
@@ -618,11 +620,27 @@ local function get_updated_buffers(buf_nums, sorted)
   return updated
 end
 
+local function apply_buffer_filter(buf_nums, callback)
+  if not callback then
+    return buf_nums
+  end
+  local filtered = {}
+  for _, buf in ipairs(buf_nums) do
+    if callback(buf) then
+      table.insert(filtered, buf)
+    end
+  end
+  return filtered
+end
+
 --- @param preferences table
 --- @return string
 local function bufferline(preferences)
   local options = preferences.options
   local buf_nums = get_buffers_by_mode(options.view)
+  if options.custom_filter then
+    buf_nums = apply_buffer_filter(buf_nums, options.custom_filter)
+  end
   buf_nums = get_updated_buffers(buf_nums, state.custom_sort)
   local all_tabs = tabs.get(options.separator_style, preferences)
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -625,7 +625,7 @@ end
 ---@param callback fun(buf: integer): boolean
 ---@return integer[]
 local function apply_buffer_filter(buf_nums, callback)
-  if not callback or type(callback) ~= "function" then
+  if type(callback) ~= "function" then
     return buf_nums
   end
   local filtered = {}

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -620,8 +620,12 @@ local function get_updated_buffers(buf_nums, sorted)
   return updated
 end
 
+---Filter the buffers to show based on the user callback passed in
+---@param buf_nums integer[]
+---@param callback fun(buf: integer): boolean
+---@return integer[]
 local function apply_buffer_filter(buf_nums, callback)
-  if not callback then
+  if not callback or type(callback) ~= "function" then
     return buf_nums
   end
   local filtered = {}

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -52,7 +52,7 @@ end
 --------------------------------
 -- A single buffer
 --------------------------------
---- @class Buffer @parent class
+--- @class Buffer
 M.Buffer = {
   extension = nil,
   path = nil,

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -11,58 +11,31 @@ local M = {}
 local terminal_icon = " "
 local terminal_buftype = "terminal"
 
---------------------------------
--- A collection of buffers
---------------------------------
---- @class Buffers @parent class
-M.Buffers = {
-  buffers = nil
-}
-
-function M.Buffers:new(n)
-  local t = n or {length = 0, buffers = {}}
-  self.__index = self
-  return setmetatable(t, self)
-end
-
-function M.Buffers.__add(a, b)
-  return a.length + b.length
-end
-
--- Take a section and remove a buffer arbitrarily
--- reducing the length is very important as otherwise we don't know
--- a section is actually smaller now
-function M.Buffers:drop(index)
-  if self.buffers[index] ~= nil then
-    self.length = self.length - self.buffers[index].length
-    table.remove(self.buffers, index)
-    return self
-  end
-end
-
-function M.Buffers:add(buf)
-  table.insert(self.buffers, buf)
-  self.length = self.length + buf.length
-end
-
+-----------------------------------------------------------------------------//
+-- helpers
+-----------------------------------------------------------------------------//
 local function buffer_is_terminal(buf)
   return string.find(buf.path, "term://") or buf.buftype == terminal_buftype
 end
-
 --------------------------------
 -- A single buffer
 --------------------------------
---- @class Buffer
-M.Buffer = {
-  extension = nil,
-  path = nil,
-  id = nil,
-  filename = nil,
-  icon = nil,
-  icon_highlight = nil,
-  diagnostics = nil
-}
+---@class Buffer
+---@field public extension string,
+---@field public path string,
+---@field public id integer,
+---@field public filename string,
+---@field public icon string,
+---@field public icon_highlight string,
+---@field public diagnostics table
+---@field public modified boolean
+---@field public modifiable boolean
+---@field public buftype string
+M.Buffer = {}
 
+---create a new buffer class
+---@param buf Buffer
+---@return Buffer
 function M.Buffer:new(buf)
   buf.modifiable = vim.bo[buf.id].modifiable
   buf.modified = vim.bo[buf.id].modified
@@ -95,7 +68,6 @@ end
 -- have the main selected highlighting. If it isn't but it is the window highlight it as inactive
 -- the "trick" here is that "bufwinnr" retunrs a value which is the first window associated with a buffer
 -- if there are no windows associated i.e. it is not in view and the function returns -1
-
 -- FIXME this does not work if the same buffer is open in multiple window
 -- maybe do something with win_findbuf(bufnr('%'))
 function M.Buffer:current()
@@ -124,6 +96,43 @@ function M.Buffer:ancestor(depth, formatter)
     ancestor = dir .. utils.path_sep .. ancestor
   end
   return ancestor
+end
+
+--------------------------------
+-- A collection of buffers
+--------------------------------
+
+---@class Buffers
+---@field buffers Buffers[]
+M.Buffers = {}
+
+---create a segment of buffers
+---@param n Buffers
+---@return Buffers
+function M.Buffers:new(n)
+  local t = n or {length = 0, buffers = {}}
+  self.__index = self
+  return setmetatable(t, self)
+end
+
+function M.Buffers.__add(a, b)
+  return a.length + b.length
+end
+
+-- Take a section and remove a buffer arbitrarily
+-- reducing the length is very important as otherwise we don't know
+-- a section is actually smaller now
+function M.Buffers:drop(index)
+  if self.buffers[index] ~= nil then
+    self.length = self.length - self.buffers[index].length
+    table.remove(self.buffers, index)
+    return self
+  end
+end
+
+function M.Buffers:add(buf)
+  table.insert(self.buffers, buf)
+  self.length = self.length + buf.length
 end
 
 return M


### PR DESCRIPTION
This PR will provide the ability for a user to specify a custom filter function to determine which buffers should not be shown in the bufferline. A user could always do something like `set bufnolisted` etc for a filetype to prevent it from showing up but with a custom filter function they can now do it based on more complex set of circumstances/data.

This is quite similar/relates to #38, cc @cooper-anderson if you are still interested