### PR TITLE
feat: add offset for sidebar windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ require'bufferline'.setup{
         return true
       end
     end,
-    panels = {{filetype = "NvimTree", text = "File Explorer"}},
+    offsets = {{filetype = "NvimTree", text = "File Explorer"}},
     show_buffer_close_icons = true | false,
     show_close_icon = true | false,
     show_tab_indicators = true | false,
@@ -285,10 +285,10 @@ buffers according to the buffer numbers given by vim.
 ### Sidebar Offset
 
 You can prevent the bufferline drawing above a **vertical** sidebar split such as a file explorer.
-To do this you must set the `panels` configuration option to a list of tables containing the details of the window to avoid.
+To do this you must set the `offsets` configuration option to a list of tables containing the details of the window to avoid.
 *NOTE:* this is only relevant for left or right aligned sidebar windows such as `NvimTree`, `NERDTree` or `Vista`
 ```lua
-panels = {{filetype = "NvimTree", text = "File Explorer", highlight = "Directory"}}
+offsets = {{filetype = "NvimTree", text = "File Explorer", highlight = "Directory"}}
 ```
 The `filetype` is used to check whether a particular window is a match, the `text` is *optional* and will show above the window if specified.
 If it is too long it will be truncated. The highlight controls what highlight is shown above the window.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ see: `:h bufferline-styling`
 
 ![LSP error](https://user-images.githubusercontent.com/22454918/111993085-1d299700-8b0e-11eb-96eb-c1c289e36b08.png)
 
+#### Sidebar offset
+
+![explorer header](https://user-images.githubusercontent.com/22454918/117363338-5fd3e280-aeb4-11eb-99f2-5ec33dff6f31.png)
+
 #### Option to show buffer numbers
 
 ![bufferline with numbers](https://user-images.githubusercontent.com/22454918/111993201-3d595600-8b0e-11eb-8944-387ed3bd25b4.png)
@@ -170,6 +174,7 @@ require'bufferline'.setup{
         return true
       end
     end,
+    panels = {{filetype = "NvimTree", text = "File Explorer"}},
     show_buffer_close_icons = true | false,
     show_close_icon = true | false,
     show_tab_indicators = true | false,
@@ -276,6 +281,17 @@ end
 When using a sorted bufferline it's advisable that you use the `BufferLineCycleNext` and `BufferLineCyclePrev`
 commands since these will traverse the bufferline bufferlist in order whereas `bnext` and `bprev` will cycle
 buffers according to the buffer numbers given by vim.
+
+### Sidebar Offset
+
+You can prevent the bufferline drawing above a **vertical** sidebar split such as a file explorer.
+To do this you must set the `panels` configuration option to a list of tables containing the details of the window to avoid.
+*NOTE:* this is only relevant for left or right aligned sidebar windows such as `NvimTree`, `NERDTree` or `Vista`
+```lua
+panels = {{filetype = "NvimTree", text = "File Explorer", highlight = "Directory"}}
+```
+The `filetype` is used to check whether a particular window is a match, the `text` is *optional* and will show above the window if specified.
+If it is too long it will be truncated. The highlight controls what highlight is shown above the window.
 
 ### Bufferline Pick functionality
 

--- a/README.md
+++ b/README.md
@@ -292,6 +292,7 @@ offsets = {{filetype = "NvimTree", text = "File Explorer", highlight = "Director
 ```
 The `filetype` is used to check whether a particular window is a match, the `text` is *optional* and will show above the window if specified.
 If it is too long it will be truncated. The highlight controls what highlight is shown above the window.
+You can also add a `padding` key which should be an integer if you want the offset to be larger than the window width.
 
 ### Bufferline Pick functionality
 

--- a/doc/bufferline-lua.txt
+++ b/doc/bufferline-lua.txt
@@ -73,9 +73,10 @@ The available settings are: >
             separator_style = "slant" | "thick" | "thin" | { "any", "any" },
             enforce_regular_tabs = false | true,
             always_show_bufferline = true | false,
+            offsets = {{filetype = "NvimTree", text = "File Explorer"}},
             sort_by = "extension" | "relative_directory" | "directory" | function(buffer_a, buffer_b)
             -- add custom logic
-            return buffer_a.modified > buffer_b.modified
+                return buffer_a.modified > buffer_b.modified
             end
         }
     }
@@ -214,6 +215,26 @@ For example: >
         return (tab_num == 2 and is_log) or (tab_num ~= 2 and not is_log)
     end
 <
+
+==============================================================================
+SIDEBAR OFFSET                                           *bufferline-lua-offset*
+
+You can prevent the bufferline drawing above a *vertical* sidebar split such as a file explorer.
+To do this you must set the `offsets` configuration option to a list of tables
+containing the details of the window to avoid. *NOTE:* this is only relevant
+for left or right aligned sidebar windows such as `NvimTree`, `NERDTree` or
+`Vista`
+>
+    offsets = {{filetype = "NvimTree", text = "File Explorer", highlight = "Directory"}}
+<
+The `filetype` is used to check whether a particular window is a match, the
+`text` is *optional* and will show above the window if specified. If it is too
+long it will be truncated. The highlight controls what highlight is shown
+above the window.
+Lastly you can specify a `padding` option as well which will increase the
+amount the bufferline is offset beyond just the window width, this isn't
+something that is generally required though.
+
 ==============================================================================
 BUFFERLINE PICK                                            *bufferline-lua-pick*
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -583,8 +583,8 @@ local function render(bufs, tbs, prefs)
   local left_element_size = strwidth(join(padding, padding, left_trunc_icon, padding, padding))
   local right_element_size = strwidth(join(padding, padding, right_trunc_icon, padding))
 
-  local panel, panel_size, _ = require("bufferline.panels").get(prefs)
-  local available_width = vim.o.columns - panel_size - tabs_length - close_length
+  local panels_size, left_panel, right_panel = require("bufferline.panels").get(prefs)
+  local available_width = vim.o.columns - panels_size - tabs_length - close_length
   local before, current, after = get_sections(bufs)
   local line, marker = truncate(before, current, after, available_width, {
     left_count = 0,
@@ -602,7 +602,16 @@ local function render(bufs, tbs, prefs)
     line = join(line, hl.background.hl, icon)
   end
 
-  return join(panel, line, hl.fill.hl, right_align, tab_components, hl.tab_close.hl, close)
+  return join(
+    left_panel,
+    line,
+    hl.fill.hl,
+    right_align,
+    tab_components,
+    hl.tab_close.hl,
+    close,
+    right_panel
+  )
 end
 
 --- TODO can this be done more efficiently in one loop?

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -583,7 +583,7 @@ local function render(bufs, tbs, prefs)
   local left_element_size = strwidth(join(padding, padding, left_trunc_icon, padding, padding))
   local right_element_size = strwidth(join(padding, padding, right_trunc_icon, padding))
 
-  local offset_size, left_section, right_section = require("bufferline.offset").get(prefs)
+  local offset_size, left_offset, right_offset = require("bufferline.offset").get(prefs)
   local available_width = vim.o.columns - offset_size - tabs_length - close_length
   local before, current, after = get_sections(bufs)
   local line, marker = truncate(before, current, after, available_width, {
@@ -603,14 +603,14 @@ local function render(bufs, tbs, prefs)
   end
 
   return join(
-    left_section,
+    left_offset,
     line,
     hl.fill.hl,
     right_align,
     tab_components,
     hl.tab_close.hl,
     close,
-    right_section
+    right_offset
   )
 end
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -583,8 +583,8 @@ local function render(bufs, tbs, prefs)
   local left_element_size = strwidth(join(padding, padding, left_trunc_icon, padding, padding))
   local right_element_size = strwidth(join(padding, padding, right_trunc_icon, padding))
 
-  local panels_size, left_panel, right_panel = require("bufferline.panels").get(prefs)
-  local available_width = vim.o.columns - panels_size - tabs_length - close_length
+  local offset_size, left_section, right_section = require("bufferline.offset").get(prefs)
+  local available_width = vim.o.columns - offset_size - tabs_length - close_length
   local before, current, after = get_sections(bufs)
   local line, marker = truncate(before, current, after, available_width, {
     left_count = 0,
@@ -603,14 +603,14 @@ local function render(bufs, tbs, prefs)
   end
 
   return join(
-    left_panel,
+    left_section,
     line,
     hl.fill.hl,
     right_align,
     tab_components,
     hl.tab_close.hl,
     close,
-    right_panel
+    right_section
   )
 end
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -583,7 +583,8 @@ local function render(bufs, tbs, prefs)
   local left_element_size = strwidth(join(padding, padding, left_trunc_icon, padding, padding))
   local right_element_size = strwidth(join(padding, padding, right_trunc_icon, padding))
 
-  local available_width = vim.o.columns - tabs_length - close_length
+  local panel, panel_size, _ = require("bufferline.panels").get(prefs)
+  local available_width = vim.o.columns - panel_size - tabs_length - close_length
   local before, current, after = get_sections(bufs)
   local line, marker = truncate(before, current, after, available_width, {
     left_count = 0,
@@ -601,7 +602,7 @@ local function render(bufs, tbs, prefs)
     line = join(line, hl.background.hl, icon)
   end
 
-  return join(line, hl.fill.hl, right_align, tab_components, hl.tab_close.hl, close)
+  return join(panel, line, hl.fill.hl, right_align, tab_components, hl.tab_close.hl, close)
 end
 
 --- TODO can this be done more efficiently in one loop?

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -92,7 +92,7 @@ function M.get_defaults()
       sort_by = "default",
       diagnostics = false,
       diagnostic_indicator = nil,
-      panels = {},
+      offsets = {},
     },
     highlights = {
       fill = {

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -92,6 +92,7 @@ function M.get_defaults()
       sort_by = "default",
       diagnostics = false,
       diagnostic_indicator = nil,
+      panels = {},
     },
     highlights = {
       fill = {

--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -4,7 +4,7 @@ local api = vim.api
 ---------------------------------------------------------------------------//
 local M = {}
 
-local function hl(item)
+function M.hl(item)
   return "%#" .. item .. "#"
 end
 
@@ -59,7 +59,7 @@ function M.set_all(user_colors)
     local formatted = "BufferLine" .. name:gsub("_(.)", name.upper):gsub("^%l", string.upper)
     M.set_one(formatted, tbl)
     local copy = shallow_copy(tbl)
-    copy.hl = hl(formatted)
+    copy.hl = M.hl(formatted)
     result[name] = copy
   end
   return result

--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -100,7 +100,8 @@ function M.get(prefs)
         local is_valid, win_id, is_left = is_offset_section(layout[2], offset)
         if is_valid then
           local win_width = api.nvim_win_get_width(win_id)
-          local sign_width = vim.wo[win_id].signcolumn and 1 or 0
+          local sign_column = vim.wo[win_id].signcolumn
+          local sign_width = (sign_column and sign_column ~= "") and 1 or 0
 
           local hl_name = offset.highlight
             or guess_window_highlight(win_id)
@@ -109,8 +110,9 @@ function M.get(prefs)
           local hl = require("bufferline.highlights").hl(hl_name)
 
           local size = win_width + sign_width
-          total_size = total_size + size
           local component = get_section_text(size, hl, offset.text)
+
+          total_size = total_size + size
 
           if is_left then
             left = component

--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -8,12 +8,12 @@ local t = {
   ROW = "row",
 }
 
----Format the content of a neighbouring panel text
+---Format the content of a neighbouring offset's text
 ---@param size number
 ---@param highlight string
 ---@param text string
 ---@return string
-local function get_panel_text(size, highlight, text)
+local function get_section_text(size, highlight, text)
   if not text then
     text = string.rep(" ", size)
   else
@@ -57,11 +57,11 @@ end
 --- NOTE: this only tests the first and last windows as those are the only
 --- ones that it makes sense to add a panel for
 ---@param windows table[]
----@param panel table
+---@param offset table
 ---@return boolean
 ---@return number
 ---@return boolean
-local function is_panel(windows, panel)
+local function is_offset_section(windows, offset)
   local wins = {windows[1]}
   if #windows > 1 then
     wins[#wins+1] = windows[#windows]
@@ -70,7 +70,7 @@ local function is_panel(windows, panel)
     local _type, win_id = win[1], win[2]
     if _type == t.LEAF and type(win_id) == "number" then
       local buf = api.nvim_win_get_buf(win_id)
-      local valid = buf and vim.bo[buf].filetype == panel.filetype
+      local valid = buf and vim.bo[buf].filetype == offset.filetype
       local is_left = idx == 1
       if valid then
         return valid, win_id, is_left
@@ -86,23 +86,23 @@ end
 ---@return string
 ---@return string
 function M.get(prefs)
-  local panels = prefs.options.panels
+  local offsets = prefs.options.offsets
 
   local left = ""
   local right = ""
   local total_size = 0
 
-  if panels and #panels > 0 then
+  if offsets and #offsets > 0 then
     local layout = fn.winlayout()
-    for _, panel in ipairs(panels) do
+    for _, offset in ipairs(offsets) do
       -- don't bother proceeding if there are no vertical splits
       if layout[1] == t.ROW then
-        local is_valid, win_id, is_left = is_panel(layout[2], panel)
+        local is_valid, win_id, is_left = is_offset_section(layout[2], offset)
         if is_valid then
           local win_width = api.nvim_win_get_width(win_id)
           local sign_width = vim.wo[win_id].signcolumn and 1 or 0
 
-          local hl_name = panel.highlight
+          local hl_name = offset.highlight
             or guess_window_highlight(win_id)
             or prefs.highlights.fill.hl
 
@@ -110,7 +110,7 @@ function M.get(prefs)
 
           local size = win_width + sign_width
           total_size = total_size + size
-          local component = get_panel_text(size, hl, panel.text)
+          local component = get_section_text(size, hl, offset.text)
 
           if is_left then
             left = component

--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -103,7 +103,7 @@ function M.get(prefs)
       if layout[1] == t.ROW then
         local is_valid, win_id, is_left = is_offset_section(layout[2], offset)
         if is_valid then
-          local width = api.nvim_win_get_width(win_id)
+          local width = api.nvim_win_get_width(win_id) + (offset.padding or 0)
 
           local hl_name = offset.highlight
             or guess_window_highlight(win_id)

--- a/lua/bufferline/offset.lua
+++ b/lua/bufferline/offset.lua
@@ -19,8 +19,8 @@ local function get_section_text(size, highlight, text)
   else
     local text_size = fn.strwidth(text)
     -- 2 here is for padding on either side of the text
-    if text_size + 2 > size then
-      text = " " .. text:sub(1, text_size - size - 2) .. " "
+    if text_size + 2 >= size then
+      text = " " .. text:sub(1, size - 2) .. " "
     else
       local remainder = size - text_size
       local is_even, side = remainder % 2 == 0, remainder / 2

--- a/lua/bufferline/panels.lua
+++ b/lua/bufferline/panels.lua
@@ -1,0 +1,121 @@
+local M = {}
+
+local api = vim.api
+local fn = vim.fn
+
+local t = {
+  LEAF = "leaf",
+  ROW = "row",
+}
+
+local s = {
+  LEFT = 0,
+  RIGHT = 1,
+  NONE = 2,
+}
+
+---Format the content of a neighbouring panel text
+---@param size number
+---@param highlight string
+---@param text string
+---@return string
+local function get_panel_text(size, highlight, text)
+  if not text then
+    text = string.rep(" ", size)
+  else
+    local text_size = fn.strwidth(text)
+    -- 2 here is for padding on either side of the text
+    if text_size > size then
+      text = " " .. text:sub(1, text_size - size - 2) .. " "
+    elseif text_size < size then
+      local pad_size = math.floor((size - text_size) / 2)
+      local pad = string.rep(" ", pad_size)
+      text = pad .. text .. pad
+    end
+  end
+  return highlight .. text
+end
+
+---A heuristic to attempt to derive a windows background color from a winhighlight
+---@param win_id number
+---@param attribute string
+---@param match string
+---@return string|nil
+local function guess_window_highlight(win_id, attribute, match)
+  assert(win_id, 'A window id must be passed to "guess_window_highlight"')
+  attribute = attribute or "bg"
+  match = match or "Normal"
+  local hl = vim.wo[win_id].winhighlight
+  if not hl then
+    return
+  end
+  local parts = vim.split(hl, ",")
+  for _, part in ipairs(parts) do
+    local grp, hl_name = unpack(vim.split(part, ":"))
+    if grp and grp:match(match) then
+      return hl_name
+    end
+  end
+  return match
+end
+
+--- Test if the windows within a layout row contain the correct panel buffer
+--- NOTE: this only tests the first and last windows as those are the only
+--- ones that it makes sense to add a panel for
+---@param windows table[]
+---@param panel table
+---@return boolean
+---@return number
+---@return number
+local function is_panel(windows, panel)
+  for idx, window in ipairs({ windows[1], windows[#windows] }) do
+    local _type, win_id = window[1], window[2]
+    if _type == t.LEAF and type(win_id) == "number" then
+      local buf = api.nvim_win_get_buf(win_id)
+      local valid = buf and vim.bo[buf].filetype == panel.filetype
+      local side = idx == 0 and s.LEFT or s.RIGHT
+      return valid, win_id, side
+    end
+  end
+  return false, nil, s.NONE
+end
+
+---Calculate the size of padding required to offset the bufferline
+---@param prefs table
+---@return string
+---@return number
+---@return string
+function M.get(prefs)
+  local panels = prefs.options.panels
+
+  local component = ""
+  local size = 0
+  local side = s.NONE
+
+  if panels and #panels > 0 then
+    local panel = panels[1]
+    local layout = fn.winlayout()
+    -- don't bother proceeding if there are no vertical splits
+    if layout[1] == t.ROW then
+      local is_valid, win_id, pan_side = is_panel(layout[2], panel)
+      if is_valid then
+        local win_width = api.nvim_win_get_width(win_id)
+        local sign_width = vim.wo[win_id].signcolumn and 1 or 0
+
+        local hl_name = panel.highlight
+          or guess_window_highlight(win_id)
+          or prefs.highlights.fill.hl
+
+        local hl = require("bufferline.highlights").hl(hl_name)
+
+        side = pan_side
+        size = win_width + sign_width
+
+        component = get_panel_text(size, hl, panel.text)
+      end
+    end
+  end
+  return component, size, side
+end
+
+return M

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -88,9 +88,8 @@ function M.is_valid(buf_num)
   if not buf_num or buf_num < 1 then
     return false
   end
-  local listed = vim.fn.getbufvar(buf_num, "&buflisted") == 1
   local exists = vim.api.nvim_buf_is_valid(buf_num)
-  return listed and exists
+  return vim.bo[buf_num].buflisted and exists
 end
 
 --- @param bufs table | nil

--- a/tests/offset_spec.lua
+++ b/tests/offset_spec.lua
@@ -107,4 +107,17 @@ describe("Offset tests:", function()
     assert.is_truthy(right:match("Right"))
     assert.equal(40, size)
   end)
+
+  it('should allow setting some extra padding', function()
+    local ft1 = open_test_panel()
+    local size, left, _ = offsets.get({
+      highlights = {},
+      options = {
+        offsets = { { filetype = ft1, text = "Left", padding = 5 } },
+      },
+    })
+
+    assert.is_truthy(left:match("Left"))
+    assert.equal(25, size)
+  end)
 end)

--- a/tests/offset_spec.lua
+++ b/tests/offset_spec.lua
@@ -1,0 +1,58 @@
+local fmt = string.format
+
+local filetype = "test"
+
+local function open_test_panel(ft, direction)
+  direction = direction or "H"
+  ft = ft or filetype
+  vim.cmd("vsplit")
+  vim.cmd(fmt("wincmd %s", direction))
+  vim.cmd("vertical resize 20")
+  vim.cmd(fmt("setfiletype %s", ft))
+end
+
+describe("Offset tests:", function()
+  local offsets = require("bufferline.offset")
+  it("should not trigger if no offsets are specified", function()
+    local size, left, right = offsets.get({ options = {}, highlights = {} })
+    assert.equal(0, size)
+    assert.equal(left, "")
+    assert.equal(right, "")
+  end)
+
+  it("should create an offset if a compatible panel if open", function()
+    open_test_panel()
+    local opts = {
+      highlights = {},
+      options = { offsets = { { filetype = filetype } } },
+    }
+    local size, left, right = offsets.get(opts)
+    assert.equal(21, size)
+    assert.equal(right, "")
+    assert.is_truthy(left:match(" "))
+  end)
+
+  it("should include padded text if text is specified", function()
+    open_test_panel()
+    local opts = {
+      highlights = {},
+      options = { offsets = { { filetype = filetype, text = "Test buffer" } } },
+    }
+    local size, left, right = offsets.get(opts)
+    assert.equal(21, size)
+    assert.equal(right, "")
+    assert.is_truthy(left:match("    Test buffer    "))
+  end)
+
+  it("should add the offset to the correct side", function()
+    open_test_panel(nil, "L")
+    local opts = {
+      highlights = {},
+      options = { offsets = { { filetype = filetype, text = "Test buffer" } } },
+    }
+    local size, left, right = offsets.get(opts)
+    assert.equal(21, size)
+    assert.equal(left, "")
+    assert.is_truthy(right:match("Test buffer"))
+  end)
+end)

--- a/tests/offset_spec.lua
+++ b/tests/offset_spec.lua
@@ -1,3 +1,4 @@
+local api = vim.api
 local fmt = string.format
 
 local filetype = "test"
@@ -5,14 +6,25 @@ local filetype = "test"
 local function open_test_panel(ft, direction)
   direction = direction or "H"
   ft = ft or filetype
-  vim.cmd("vsplit")
+  vim.cmd("vnew file")
   vim.cmd(fmt("wincmd %s", direction))
-  vim.cmd("vertical resize 20")
-  vim.cmd(fmt("setfiletype %s", ft))
+  local new_ft = fmt("%s_%d", ft, vim.fn.win_getid())
+  vim.cmd(fmt("setfiletype %s", new_ft))
+  api.nvim_win_set_width(0, 20)
+  return new_ft
 end
 
 describe("Offset tests:", function()
   local offsets = require("bufferline.offset")
+  vim.o.hidden = true
+  vim.o.swapfile = false
+
+  after_each(function()
+    vim.cmd("silent only")
+    --- FIXME: open a new tab so that new windows get assigned each time
+    vim.cmd("tabnew")
+  end)
+
   it("should not trigger if no offsets are specified", function()
     local size, left, right = offsets.get({ options = {}, highlights = {} })
     assert.equal(0, size)
@@ -21,10 +33,10 @@ describe("Offset tests:", function()
   end)
 
   it("should create an offset if a compatible panel if open", function()
-    open_test_panel()
+    local ft = open_test_panel()
     local opts = {
       highlights = {},
-      options = { offsets = { { filetype = filetype } } },
+      options = { offsets = { { filetype = ft } } },
     }
     local size, left, right = offsets.get(opts)
     assert.equal(21, size)
@@ -33,10 +45,10 @@ describe("Offset tests:", function()
   end)
 
   it("should include padded text if text is specified", function()
-    open_test_panel()
+    local ft = open_test_panel()
     local opts = {
       highlights = {},
-      options = { offsets = { { filetype = filetype, text = "Test buffer" } } },
+      options = { offsets = { { filetype = ft, text = "Test buffer" } } },
     }
     local size, left, right = offsets.get(opts)
     assert.equal(21, size)
@@ -45,14 +57,16 @@ describe("Offset tests:", function()
   end)
 
   it("should add the offset to the correct side", function()
-    open_test_panel(nil, "L")
-    local opts = {
+    local ft = open_test_panel(nil, "L")
+    local size, left, right = offsets.get({
       highlights = {},
-      options = { offsets = { { filetype = filetype, text = "Test buffer" } } },
-    }
-    local size, left, right = offsets.get(opts)
+      options = {
+        offsets = { { filetype = ft, text = "Test buffer" } },
+      },
+    })
+
     assert.equal(21, size)
-    assert.equal(left, "")
     assert.is_truthy(right:match("Test buffer"))
+    assert.equal("", left)
   end)
 end)

--- a/tests/offset_spec.lua
+++ b/tests/offset_spec.lua
@@ -69,4 +69,18 @@ describe("Offset tests:", function()
     assert.is_truthy(right:match("Test buffer"))
     assert.equal("", left)
   end)
+
+  it('should correctly truncate offset text', function()
+    local ft = open_test_panel()
+    local size, left, right = offsets.get({
+      highlights = {},
+      options = {
+        offsets = { { filetype = ft, text = "Test buffer buffer buffer buffer" } },
+      },
+    })
+
+    assert.equal(20, size)
+    assert.equal("", right)
+    assert.is_equal(" Test buffer buffer ", left:gsub("%%#Normal#", ""))
+  end)
 end)

--- a/tests/offset_spec.lua
+++ b/tests/offset_spec.lua
@@ -39,7 +39,7 @@ describe("Offset tests:", function()
       options = { offsets = { { filetype = ft } } },
     }
     local size, left, right = offsets.get(opts)
-    assert.equal(21, size)
+    assert.equal(20, size)
     assert.equal(right, "")
     assert.is_truthy(left:match(" "))
   end)
@@ -51,7 +51,7 @@ describe("Offset tests:", function()
       options = { offsets = { { filetype = ft, text = "Test buffer" } } },
     }
     local size, left, right = offsets.get(opts)
-    assert.equal(21, size)
+    assert.equal(20, size)
     assert.equal(right, "")
     assert.is_truthy(left:match("    Test buffer    "))
   end)
@@ -65,7 +65,7 @@ describe("Offset tests:", function()
       },
     })
 
-    assert.equal(21, size)
+    assert.equal(20, size)
     assert.is_truthy(right:match("Test buffer"))
     assert.equal("", left)
   end)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/22454918/117363338-5fd3e280-aeb4-11eb-99f2-5ec33dff6f31.png)

<details>

![image](https://user-images.githubusercontent.com/22454918/117362027-ad4f5000-aeb2-11eb-8368-a267d5dd9616.png)

</details>

This PR fixes #89 by adding an offset to the bufferline so it begins (and eventually) ends where a sidebar panel starts or ends. This gives the impression that the bufferline is local to the window, similar to GUI editors.

The implementation is based on adding padding/text before or after the bufferline so is somewhat hacky, if this somehow proves problematic in the long term this might need to be revisited +/- deprecated.

### TODO
- [x] Add documentation
- [x] Handle windows open on the right
- [x] Add tests

NOTE: I am *not* taking more feature requests on top on this functionality, I'm not going to add anything jazzier to this i.e. it will be text or an empty space above the window
