### PR TITLE
Get icon from terminal key

### DIFF
--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -45,6 +45,9 @@ function M.Buffer:new(buf)
   buf.extension = fn.fnamemodify(buf.path, ":e")
   -- Set icon
   if buffer_is_terminal(buf) then
+    if lua_devicons_loaded then
+      terminal_icon = webdev_icons.get_icon("terminal")
+    end
     buf.icon = terminal_icon
     buf.filename = fn.fnamemodify(buf.path, ":p:t")
   else

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -46,7 +46,7 @@ function M.Buffer:new(buf)
   -- Set icon
   if buffer_is_terminal(buf) then
     if lua_devicons_loaded then
-      terminal_icon = webdev_icons.get_icon("terminal")
+      terminal_icon = webdev_icons.get_icon("terminal").." "
     end
     buf.icon = terminal_icon
     buf.filename = fn.fnamemodify(buf.path, ":p:t")


### PR DESCRIPTION
I use nvim-nonicons, which has a few overrides from the original nvim-web-devicons plugins. One of which is terminal, which has the decimal value of [62601](https://github.com/kyazdani42/nvim-web-devicons/blob/1db27380053de0cd4aaabd236a67c52d33199f1a/lua/nvim-web-devicons.lua#L856) in the original plugin, whilst the nonicons plugin has the decimal value of [61911](https://github.com/yamatsum/nvim-nonicons/blob/5056aebb8d0ecc87b26a4f7fe9e9e520e5ea493f/lua/nvim-nonicons/mapping.lua#L216) for the same icon.
This results in a broken glyph, which could also be a result of my bad font patch. Either way, as long as the key is called `"terminal"`, this should fix it.