### PR TITLE
feat: add ability to add a custom section

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,6 @@ not track global variables which is the mechanism used to store your sort order.
 ```lua
 require('bufferline').setup {
   options = {
-    view = "multiwindow" | "default",
     numbers = "none" | "ordinal" | "buffer_id" | "both",
     number_style = "superscript" | "" | { "none", "subscript" }, -- buffer_id at index 1, ordinal at index 2
     mappings = true | false,

--- a/README.md
+++ b/README.md
@@ -197,13 +197,6 @@ require('bufferline').setup {
 }
 ```
 
-#### NOTE:
-
-If using a plugin such as `vim-rooter` and you want to sort by path, prefer using `directory` rather than
-`relative_directory`. Relative directory works by ordering relative paths first, however if you move from
-project to project and vim switches its directory, the bufferline will re-order itself as a different set of
-buffers will now be relative.
-
 ### LSP Error indicators
 
 By setting `diagnostics = "nvim_lsp"` you will get an indicator in the bufferline for a given tab if it has any errors
@@ -260,6 +253,11 @@ the tab size and all tabs will be the same length
 
 Bufferline allows you to sort the visible buffers by `extension` or `directory`:
 
+**NOTE**: If using a plugin such as `vim-rooter` and you want to sort by path, prefer using `directory` rather than
+`relative_directory`. Relative directory works by ordering relative paths first, however if you move from
+project to project and vim switches its directory, the bufferline will re-order itself as a different set of
+buffers will now be relative.
+
 ```vim
 " Using vim commands
 :BufferLineSortByExtension
@@ -314,22 +312,45 @@ buffer that appears
 
 ![bufferline_pick](https://user-images.githubusercontent.com/22454918/111994691-f2404280-8b0f-11eb-9bc1-6664ccb93154.gif)
 
-### Multi-window mode
+### Custom Area (Advanced)
 
-When this mode is active, for layouts of multiple windows in the tabpage,
-only the buffers that are displayed in those windows are listed in the
-tabline. That only applies to multi-window layouts, if there is only one
-window in the tabpage, all buffers are listed.
+![image](https://user-images.githubusercontent.com/22454918/118525973-aa1c5580-b737-11eb-883c-a2c55b7af479.png)
 
-### Mappings
+You can also add custom content at the start or end of the bufferline using `custom_areas`
+this option allow a user to specify a function which return the text and highlight for that text
+to be shown. For example:
+```lua
 
-If the `mappings` option is set to `true`. `<leader>`1-9 mappings will
-be created to navigate the first to the tenth buffer in the bufferline.
-**This is false by default**. If you'd rather map these yourself, use:
+custom_areas = {
+  right = function()
+    local result = {}
+    local error = vim.lsp.diagnostic.get_count(0, [[Error]])
+    local warning = vim.lsp.diagnostic.get_count(0, [[Warning]])
+    local info = vim.lsp.diagnostic.get_count(0, [[Information]])
+    local hint = vim.lsp.diagnostic.get_count(0, [[Hint]])
 
-```vim
-nnoremap mymap :lua require"bufferline".go_to_buffer(num)<CR>
+    if error ~= 0 then
+    result[1] = {text = "  " .. error, guifg = "#EC5241"}
+    end
+
+    if warning ~= 0 then
+    result[2] = {text = "  " .. warning, guifg = "#EFB839"}
+    end
+
+    if hint ~= 0 then
+    result[3] = {text = "  " .. hint, guifg = "#A3BA5E"}
+    end
+
+    if info ~= 0 then
+    result[4] = {text = "  " .. info, guifg = "#7EA9A7"}
+  end
+  return result
+end
+}
 ```
+
+Please note that this function will be called a lot and should be as inexpensive as possible so it does
+not block rendering the tabline.
 
 ### FAQ
 

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ buffer that appears
 
 ### Custom Area (Advanced)
 
-![image](https://user-images.githubusercontent.com/22454918/118525973-aa1c5580-b737-11eb-883c-a2c55b7af479.png)
+![custom area example](https://user-images.githubusercontent.com/22454918/118527523-4d219f00-b739-11eb-889f-60fb06fd71bc.png)
 
 You can also add custom content at the start or end of the bufferline using `custom_areas`
 this option allow a user to specify a function which return the text and highlight for that text

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -583,7 +583,14 @@ local function render(bufs, tbs, prefs)
   local right_element_size = strwidth(join(padding, padding, right_trunc_icon, padding))
 
   local offset_size, left_offset, right_offset = require("bufferline.offset").get(prefs)
-  local available_width = vim.o.columns - offset_size - tabs_length - close_length
+  local custom_area_size, left_area, right_area = require("bufferline.custom_area").get(prefs)
+
+  local available_width = vim.o.columns
+    - custom_area_size
+    - offset_size
+    - tabs_length
+    - close_length
+
   local before, current, after = get_sections(bufs)
   local line, marker = truncate(before, current, after, available_width, {
     left_count = 0,
@@ -603,12 +610,14 @@ local function render(bufs, tbs, prefs)
 
   return join(
     left_offset,
+    left_area,
     line,
     hl.fill.hl,
     right_align,
     tab_components,
     hl.tab_close.hl,
     close,
+    right_area,
     right_offset
   )
 end

--- a/lua/bufferline/custom_area.lua
+++ b/lua/bufferline/custom_area.lua
@@ -38,7 +38,8 @@ function M.get(prefs)
           ))
       end
       -- if the user doesn't specify a background use the default
-      local guibg = prefs.highlights.fill.guibg
+      local hls = prefs.highlights or {}
+      local guibg = hls.fill and hls.fill.guibg or nil
       local ok, section = pcall(section_fn)
       if ok and section and not vim.tbl_isempty(section) then
         for i, item in ipairs(section) do

--- a/lua/bufferline/custom_area.lua
+++ b/lua/bufferline/custom_area.lua
@@ -36,10 +36,10 @@ function M.get(prefs)
             vim.inspect(side)
           ))
       end
-      local section = section_fn()
-      if section and not vim.tbl_isempty(section) then
+      local ok, section = pcall(section_fn)
+      if ok and section and not vim.tbl_isempty(section) then
         for i, item in ipairs(section) do
-          if item.text then
+          if item.text and type(item.text) == "string" then
             local hl = create_hl(i, side, item)
             size = size + fn.strwidth(item.text)
             if side == "left" then

--- a/lua/bufferline/custom_area.lua
+++ b/lua/bufferline/custom_area.lua
@@ -6,12 +6,13 @@ local fmt = string.format
 ---@param index integer
 ---@param side string
 ---@param section table
-local function create_hl(index, side, section)
+---@param guibg string
+local function create_hl(index, side, section, guibg)
   local name = fmt("BufferLine%sCustomAreaText%d", side:gsub("^%l", string.upper), index)
   local H = require("bufferline.highlights")
   H.set_one(name, {
     guifg = section.guifg,
-    guibg = section.guibg,
+    guibg = section.guibg or guibg,
     gui = section.gui,
   })
   return H.hl(name)
@@ -36,11 +37,13 @@ function M.get(prefs)
             vim.inspect(side)
           ))
       end
+      -- if the user doesn't specify a background use the default
+      local guibg = prefs.highlights.fill.guibg
       local ok, section = pcall(section_fn)
       if ok and section and not vim.tbl_isempty(section) then
         for i, item in ipairs(section) do
           if item.text and type(item.text) == "string" then
-            local hl = create_hl(i, side, item)
+            local hl = create_hl(i, side, item, guibg)
             size = size + fn.strwidth(item.text)
             if side == "left" then
               left = left .. hl .. item.text

--- a/lua/bufferline/custom_area.lua
+++ b/lua/bufferline/custom_area.lua
@@ -1,0 +1,58 @@
+local M = {}
+local fn = vim.fn
+local fmt = string.format
+
+---generate a custom highlight group
+---@param index integer
+---@param side string
+---@param section table
+local function create_hl(index, side, section)
+  local name = fmt("BufferLine%sCustomAreaText%d", side:gsub("^%l", string.upper), index)
+  local H = require("bufferline.highlights")
+  H.set_one(name, {
+    guifg = section.guifg,
+    guibg = section.guibg,
+    gui = section.gui,
+  })
+  return H.hl(name)
+end
+
+---Create tabline segment for custom user specified sections
+---@param prefs table
+---@return integer
+---@return string
+---@return string
+function M.get(prefs)
+  local size = 0
+  local left = ""
+  local right = ""
+  ---@type table<string,function>
+  local areas = prefs.options.custom_areas
+  if areas then
+    for side, section_fn in pairs(areas) do
+      if type(section_fn) ~= "function" then
+        return require("bufferline.utils").echoerr(fmt(
+            "each side should be a function but you passed in %s",
+            vim.inspect(side)
+          ))
+      end
+      local section = section_fn()
+      if section and not vim.tbl_isempty(section) then
+        for i, item in ipairs(section) do
+          if item.text then
+            local hl = create_hl(i, side, item)
+            size = size + fn.strwidth(item.text)
+            if side == "left" then
+              left = left .. hl .. item.text
+            else
+              right = right .. hl .. item.text
+            end
+          end
+        end
+      end
+    end
+  end
+  return size, left, right
+end
+
+return M

--- a/tests/custom_area_spec.lua
+++ b/tests/custom_area_spec.lua
@@ -17,6 +17,9 @@ describe('Custom areas -', function()
 
   it('should handle sides correctly', function()
     local size, left, right = areas.get({
+      highlights = {
+        fill = "#000000"
+      },
       options = {
         custom_areas = {
           left = function ()

--- a/tests/custom_area_spec.lua
+++ b/tests/custom_area_spec.lua
@@ -36,4 +36,22 @@ describe('Custom areas -', function()
     assert.is_truthy(right)
     assert.is_equal('%#BufferLineRightCustomAreaText1#test1', right)
   end)
+
+  it('should handle user errors gracefully', function()
+    local size, left, right = areas.get({
+      options = {
+        custom_areas = {
+          left = function ()
+            return {{text = {"test"}, guifg = "red", guibg = "black"}}
+          end,
+          right = function ()
+            error('This failed mysteriously')
+          end
+        }
+      }
+    })
+    assert.is_equal(0, size)
+    assert.is_equal("", left)
+    assert.is_equal("", right)
+  end)
 end)

--- a/tests/custom_area_spec.lua
+++ b/tests/custom_area_spec.lua
@@ -1,0 +1,39 @@
+describe('Custom areas -', function()
+  local areas = require("bufferline.custom_area")
+  it('should generate a custom area from config', function()
+    local size, left = areas.get({
+      options = {
+        custom_areas = {
+          left = function ()
+            return {{text = "test", guifg = "red", guibg = "black"}}
+          end
+        }
+      }
+    })
+    assert.is_truthy(left)
+    assert.is_equal(4, size)
+    assert.is_equal('%#BufferLineLeftCustomAreaText1#test', left)
+  end)
+
+  it('should handle sides correctly', function()
+    local size, left, right = areas.get({
+      options = {
+        custom_areas = {
+          left = function ()
+            return {{text = "test", guifg = "red", guibg = "black"}}
+          end,
+          right = function ()
+            return {{text = "test1", gui = "italic"}}
+          end
+        }
+      }
+    })
+    assert.is_equal(9, size)
+
+    assert.is_truthy(left)
+    assert.is_equal('%#BufferLineLeftCustomAreaText1#test', left)
+
+    assert.is_truthy(right)
+    assert.is_equal('%#BufferLineRightCustomAreaText1#test1', right)
+  end)
+end)


### PR DESCRIPTION
This will allow a user to specify a custom section on either end of the statusline.
This can be used as
```lua
config = {
 options = {
	custom_areas = {
		left = function()
	 		return {
       			text = "  " .. vim.lsp.diagnostic.get_count(0, "Error"),
       			guifg = "salmon",
     		},
		end
		}
 	}
}
```
![image](https://user-images.githubusercontent.com/22454918/118381306-9c54bc00-b5e1-11eb-93d2-4835b1b2310c.png)


Fixes #98, cc @weilbith can you give this a try and see if it works for you. I really don't want to go down any rabbit holes having to add refresh logic or anything so if it doesn't I might have to scrap this.