### PR TITLE
fix: add padded slant style for some terminals

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ Table of Contents
 
 ![slanted tabs](https://user-images.githubusercontent.com/22454918/111992989-fec39b80-8b0d-11eb-851b-010641196a04.png)
 
-**NOTE**: some terminals require special characters to be padded so set style to `padded_slant` if the appearance isn't right in your terminal emulator.
-Please keep in mind though that results may vary depending on your terminal emulator of choice and this style might will not work for all terminals
+**NOTE**: some terminals require special characters to be padded so set the style to `padded_slant` if the appearance isn't right in your terminal emulator. Please keep in mind
+though that results may vary depending on your terminal emulator of choice and this style might will not work for all terminals
 
 see: `:h bufferline-styling`
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ Table of Contents
 
 ![slanted tabs](https://user-images.githubusercontent.com/22454918/111992989-fec39b80-8b0d-11eb-851b-010641196a04.png)
 
-**NOTE**: tested with [`kitty`](https://github.com/kovidgoyal/kitty), [`alacritty`](https://github.com/alacritty/alacritty), `gnome terminal`, results may vary depending on your terminal emulator of choice
+**NOTE**: some terminals require special characters to be padded so set style to `padded_slant` if the appearance isn't right in your terminal emulator.
+Please keep in mind though that results may vary depending on your terminal emulator of choice and this style might will not work for all terminals
 
 see: `:h bufferline-styling`
 

--- a/doc/bufferline-lua.txt
+++ b/doc/bufferline-lua.txt
@@ -76,7 +76,7 @@ The available settings are: >
             persist_buffer_sort = true, -- whether or not custom sorted buffers should persist
             -- can also be a table containing 2 custom separators
             -- [focused and unfocused]. eg: { "|", "|" }
-            separator_style = "slant" | "thick" | "thin" | { "any", "any" },
+            separator_style = "slant" | "padded_slant" | "thick" | "thin" | { "any", "any" },
             enforce_regular_tabs = false | true,
             always_show_bufferline = true | false,
             offsets = {{filetype = "NvimTree", text = "File Explorer", text_align = "center" | "right" | "left"}},
@@ -93,6 +93,8 @@ STYLING                                             *bufferline-styling*
 You can change the appearance of the bufferline separators by setting the
 `separator_style`. The available options are:
 * `slant` - Use slanted/triangular separators
+* `padded_slant` - Same as `slant` but with extra padding which some terminals require.
+  If `slant` does not render correctly for you try padded this instead.
 * `thick` - Increase the thickness of the separator characters
 * `thin` - (default) Use thin separator characters
 * finally you can pass in a custom list containing 2 characters which will be

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -255,6 +255,13 @@ local function highlight_icon(buffer)
   return "%#" .. new_hl .. "#" .. icon .. padding .. "%*"
 end
 
+---Determine if the separator style is one of the slant options
+---@param style string
+---@return boolean
+local function is_slant(style)
+  return vim.tbl_contains({sep_names.slant, sep_names.padded_slant}, style)
+end
+
 --- "▍" "░"
 --- Reference: https://en.wikipedia.org/wiki/Block_Elements
 --- @param focused boolean
@@ -262,15 +269,12 @@ end
 local function get_separator(focused, style)
   if type(style) == "table" then
     return focused and style[1] or style[2]
-  elseif style == sep_names.thick then
-    return focused and sep_chars.thick[1] or sep_chars.thick[2]
-  elseif style == sep_names.slant then
-    return sep_chars.slant[1], sep_chars.slant[2]
-  elseif style == sep_names.padded_slant then
-    return sep_chars.padded_slant[1], sep_chars.padded_slant[2]
-  else
-    return focused and "▏" or "▕"
   end
+  local chars = sep_chars[style] or sep_chars.thin
+  if is_slant(style) then
+    return chars[1], chars[2]
+  end
+  return focused and chars[1] or chars[2]
 end
 
 --- @param buf_id number
@@ -303,7 +307,7 @@ local function indicator_component(context)
   if buffer:current() then
     local indicator = " "
     local symbol = indicator
-    if not vim.tbl_contains({sep_names.slant, sep_names.padded_slant}, style) then
+    if not is_slant(style) then
       symbol = options.indicator_icon
       indicator = hl.indicator_selected.hl .. symbol .. "%*"
     end
@@ -369,7 +373,7 @@ local function separator_components(context)
   local right_sep, left_sep = get_separator(focused, style)
 
   local sep_hl = hl.separator.hl
-  if style == sep_names.slant then
+  if is_slant(style) then
     sep_hl = curr_hl.separator
   end
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -12,7 +12,8 @@ local fmt = string.format
 local strwidth = vim.fn.strwidth
 
 local padding = constants.padding
-local separator_styles = constants.separator_styles
+local sep_names = constants.sep_names
+local sep_chars = constants.sep_chars
 local positions_key = constants.positions_key
 
 local M = {}
@@ -261,10 +262,12 @@ end
 local function get_separator(focused, style)
   if type(style) == "table" then
     return focused and style[1] or style[2]
-  elseif style == separator_styles.thick then
-    return focused and "▌" or "▐"
-  elseif style == separator_styles.slant then
-    return "", ""
+  elseif style == sep_names.thick then
+    return focused and sep_chars.thick[1] or sep_chars.thick[2]
+  elseif style == sep_names.slant then
+    return sep_chars.slant[1], sep_chars.slant[2]
+  elseif style == sep_names.padded_slant then
+    return sep_chars.padded_slant[1], sep_chars.padded_slant[2]
   else
     return focused and "▏" or "▕"
   end
@@ -300,7 +303,7 @@ local function indicator_component(context)
   if buffer:current() then
     local indicator = " "
     local symbol = indicator
-    if style ~= separator_styles.slant then
+    if not vim.tbl_contains({sep_names.slant, sep_names.padded_slant}, style) then
       symbol = options.indicator_icon
       indicator = hl.indicator_selected.hl .. symbol .. "%*"
     end
@@ -364,17 +367,10 @@ local function separator_components(context)
   local focused = buffer:current() or buffer:visible()
 
   local right_sep, left_sep = get_separator(focused, style)
-  local sep_hl = hl.separator.hl
-  if style == separator_styles.slant then
-    sep_hl = curr_hl.separator
-  end
 
-  --- HACK: most other terminals are unable to draw the slant character correctly without
-  --- extra right sided padding. Kitty automagically can however, so we check if it's
-  --- kitty and if so we do not pad as this breaks rendering in that terminal
-  --- Fixes #114
-  if style == "slant" and not utils.is_kitty then
-    right_sep, left_sep = right_sep .. padding, left_sep .. padding
+  local sep_hl = hl.separator.hl
+  if style == sep_names.slant then
+    sep_hl = curr_hl.separator
   end
 
   local right_separator = sep_hl .. right_sep

--- a/lua/bufferline/constants.lua
+++ b/lua/bufferline/constants.lua
@@ -4,10 +4,18 @@ local M = {}
 ---------------------------------------------------------------------------//
 M.padding = " "
 
-M.separator_styles = {
-  slant = "slant",
-  thick = "thick",
+M.sep_names = {
   thin = "thin",
+  thick = "thick",
+  slant = "slant",
+  padded_slant = "padded_slant",
+}
+
+M.sep_chars = {
+  [M.sep_names.thin] = { "▏", "▕" },
+  [M.sep_names.thick] = { "▌", "▐" },
+  [M.sep_names.slant] = { "", "" },
+  [M.sep_names.padded_slant] = { ""..M.padding, ""..M.padding },
 }
 
 M.positions_key = "BufferlinePositions"

--- a/lua/bufferline/constants.lua
+++ b/lua/bufferline/constants.lua
@@ -11,6 +11,7 @@ M.sep_names = {
   padded_slant = "padded_slant",
 }
 
+---@type table<string, string[]>
 M.sep_chars = {
   [M.sep_names.thin] = { "▏", "▕" },
   [M.sep_names.thick] = { "▌", "▐" },

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -126,19 +126,4 @@ function M.echomsg(msg, hl)
   vim.api.nvim_echo({ { fmt("[nvim-bufferline] %s", msg), hl } }, true, {})
 end
 
----@alias term_type "'kitty'"
----Determine what terminal a user is on as this can impact how
----special characters are rendered
----@return term_type
-local function get_terminal_type()
-  ---based on https://github.com/kovidgoyal/kitty/issues/957
-  if os.getenv("KITTY_WINDOW_ID") then
-    return "kitty"
-  end
-end
-
-local terminal_type = get_terminal_type()
-
-M.is_kitty = terminal_type == "kitty"
-
 return M


### PR DESCRIPTION
This fixes #125 by adding a new style specifically for terminals that required padding for the separator characters. Rather than trying to determine what terminal a user is on (since this is waaaay to brittle, and my initial assumption that kitty was an exception was wrong), the user has to decide which style to use for themselves.

@siduck76 you will need to change your config if you are using `slant` once this PR gets merged. @Racle can you see if this fixes the issue for you.