### PR TITLE
update readme with more generic custom area example [closes #128]

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,22 +443,22 @@ custom_areas = {
     local hint = vim.lsp.diagnostic.get_count(0, [[Hint]])
 
     if error ~= 0 then
-    result[1] = {text = "  " .. error, guifg = "#EC5241"}
+      table.insert(result, {text = "  " .. error, guifg = "#EC5241"})
     end
 
     if warning ~= 0 then
-    result[2] = {text = "  " .. warning, guifg = "#EFB839"}
+      table.insert(result, {text = "  " .. warning, guifg = "#EFB839"})
     end
 
     if hint ~= 0 then
-    result[3] = {text = "  " .. hint, guifg = "#A3BA5E"}
+      table.insert(result, {text = "  " .. hint, guifg = "#A3BA5E"})
     end
 
     if info ~= 0 then
-    result[4] = {text = "  " .. info, guifg = "#7EA9A7"}
-  end
-  return result
-end
+      table.insert(result, {text = "  " .. info, guifg = "#7EA9A7"})
+    end
+    return result
+  end,
 }
 ```
 


### PR DESCRIPTION
The given custom area example is working in general, but only if all 4 lsp diagnostics are greater than zero. It does not show the right area when only infos are present, for example.

This PR updates the readme to show an example of a custom area that will shown any hint. Note the replacement of `result[0] = ` with `table.insert`. This configuration fixed it for me.