### PR TITLE
refactor: defer startup

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -868,9 +868,16 @@ function M.sort_buffers_by(sort_by)
   refresh()
 end
 
+---@private
+function M.__apply_colors()
+  local config = require("bufferline.config")
+  local current_prefs = config.update_highlights()
+  require("bufferline.highlights").set_all(current_prefs.highlights)
+end
+
 local function setup_autocommands(preferences)
   local autocommands = {
-    { "ColorScheme", "*", [[lua __setup_bufferline_colors()]] },
+    { "ColorScheme", "*", [[lua require('bufferline').__apply_colors()]] },
   }
   if preferences.options.persist_buffer_sort then
     table.insert(autocommands, {
@@ -887,48 +894,13 @@ local function setup_autocommands(preferences)
       "lua require'bufferline'.toggle_bufferline()",
     })
   end
-  local loaded = pcall(require, "nvim-web-devicons")
-  if loaded then
-    table.insert(autocommands, {
-      "ColorScheme",
-      "*",
-      [[lua require'nvim-web-devicons'.setup()]],
-    })
-  end
 
-  utils.nvim_create_augroups({ BufferlineColors = autocommands })
+  utils.augroup({ BufferlineColors = autocommands })
 end
 
-function M.setup(prefs)
-  local config = require("bufferline.config")
-  local preferences = config.set(prefs)
-
-  -- on loading (and reloading) the plugin's config reset all the highlights
-  require("bufferline.highlights").set_all(preferences.highlights)
-
-  function _G.__setup_bufferline_colors()
-    local current_prefs = config.update_highlights()
-    require("bufferline.highlights").set_all(current_prefs.highlights)
-  end
-
-  setup_autocommands(preferences)
-  -----------------------------------------------------------
-  -- Commands
-  -----------------------------------------------------------
-  vim.cmd('command! BufferLinePick lua require"bufferline".pick_buffer()')
-  vim.cmd('command! BufferLineCycleNext lua require"bufferline".cycle(1)')
-  vim.cmd('command! BufferLineCyclePrev lua require"bufferline".cycle(-1)')
-  vim.cmd('command! BufferLineCloseRight lua require"bufferline".close_in_direction("right")')
-  vim.cmd('command! BufferLineCloseLeft lua require"bufferline".close_in_direction("left")')
-  vim.cmd('command! BufferLineMoveNext lua require"bufferline".move(1)')
-  vim.cmd('command! BufferLineMovePrev lua require"bufferline".move(-1)')
-  vim.cmd('command! BufferLineSortByExtension lua require"bufferline".sort_buffers_by("extension")')
-  vim.cmd('command! BufferLineSortByDirectory lua require"bufferline".sort_buffers_by("directory")')
-  vim.cmd(
-    'command! BufferLineSortByRelativeDirectory lua require"bufferline".sort_buffers_by("relative_directory")'
-  )
-
-  -- TODO / idea: consider allowing these mappings to open buffers based on their
+---@param preferences BufferlineConfig
+local function setup_mappings(preferences)
+  -- TODO: / idea: consider allowing these mappings to open buffers based on their
   -- visual position i.e. <leader>1 maps to the first visible buffer regardless
   -- of it actual ordinal number i.e. position in the full list or it's actual
   -- buffer id
@@ -938,21 +910,60 @@ function M.setup(prefs)
         "n",
         "<leader>" .. i,
         ':lua require"bufferline".go_to_buffer(' .. i .. ")<CR>",
-        {
-          silent = true,
-          nowait = true,
-          noremap = true,
-        }
+        { silent = true, nowait = true, noremap = true }
       )
     end
   end
+end
 
-  function _G.nvim_bufferline()
-    return bufferline(config.get())
+local function setup_commands()
+  local cmds = {
+    { name = "BufferLinePick", cmd = "pick_buffer()" },
+    { name = "BufferLineCycleNext", cmd = "cycle(1)" },
+    { name = "BufferLineCyclePrev", cmd = "cycle(-1)" },
+    { name = "BufferLineCloseRight", cmd = 'close_in_direction("right")' },
+    { name = "BufferLineCloseLeft", cmd = 'close_in_direction("left")' },
+    { name = "BufferLineMoveNext", cmd = "move(1)" },
+    { name = "BufferLineMovePrev", cmd = "move(-1)" },
+    { name = "BufferLineSortByExtension", cmd = 'sort_buffers_by("extension")' },
+    { name = "BufferLineSortByDirectory", cmd = 'sort_buffers_by("directory")' },
+    { name = "BufferLineSortByRelativeDirectory", cmd = 'sort_buffers_by("relative_directory")' },
+  }
+  for _, cmd in ipairs(cmds) do
+    vim.cmd(fmt('command! %s lua require("bufferline").%s', cmd.name, cmd.cmd))
   end
+end
 
+---@private
+function _G.nvim_bufferline()
+  return bufferline(require("bufferline.config").get())
+end
+
+---@private
+function M.__load()
+  local config = require("bufferline.config")
+  local preferences = config.apply()
+  -- on loading (and reloading) the plugin's config reset all the highlights
+  require("bufferline.highlights").set_all(preferences.highlights)
+  setup_commands()
+  setup_mappings(preferences)
   vim.o.showtabline = 2
   vim.o.tabline = "%!v:lua.nvim_bufferline()"
+end
+
+---@param prefs BufferlineConfig
+function M.setup(prefs)
+  require("bufferline.config").set(prefs)
+  if vim.v.vim_did_enter == 1 then
+    M.__load()
+  else
+    -- autocommands need to be setup as early as possible
+    setup_autocommands(prefs)
+    -- defer the first load of the plugin till vim has started
+    require("bufferline.utils").augroup({
+      BufferlineLoad = { { "VimEnter", "*", "++once", "lua require('bufferline').__load()" } },
+    })
+  end
 end
 
 if utils.is_test() then

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -1,9 +1,5 @@
-local buffers = require("bufferline.buffers")
 local constants = require("bufferline.constants")
 local utils = require("bufferline.utils")
-
-local Buffer = buffers.Buffer
-local Buffers = buffers.Buffers
 
 local api = vim.api
 local fmt = string.format
@@ -500,6 +496,7 @@ local function render_close(icon)
 end
 
 local function get_sections(bufs)
+  local Buffers = require("bufferline.buffers").Buffers
   local current = Buffers:new()
   local before = Buffers:new()
   local after = Buffers:new()
@@ -719,7 +716,7 @@ local function bufferline(preferences)
   duplicates.reset()
   state.buffers = {}
   local all_diagnostics = require("bufferline.diagnostics").get(options)
-
+  local Buffer = require("bufferline.buffers").Buffer
   for i, buf_id in ipairs(buf_nums) do
     local name = vim.fn.bufname(buf_id)
     local buf = Buffer:new({

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -873,17 +873,18 @@ function M.__apply_colors()
 end
 
 local function setup_autocommands(preferences)
+  local options = preferences.options or {}
   local autocommands = {
     { "ColorScheme", "*", [[lua require('bufferline').__apply_colors()]] },
   }
-  if preferences.options.persist_buffer_sort then
+  if options.persist_buffer_sort then
     table.insert(autocommands, {
       "SessionLoadPost",
       "*",
       [[lua require'bufferline'.restore_positions()]],
     })
   end
-  if not preferences.options.always_show_bufferline then
+  if not options.always_show_bufferline then
     -- toggle tabline
     table.insert(autocommands, {
       "VimEnter,BufAdd,TabEnter",
@@ -950,6 +951,7 @@ end
 
 ---@param prefs BufferlineConfig
 function M.setup(prefs)
+  prefs = prefs or {}
   require("bufferline.config").set(prefs)
   if vim.v.vim_did_enter == 1 then
     M.__load()

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -374,6 +374,7 @@ end
 
 ---@class BufferlineConfig
 ---@field public options BufferlineOptions
+---@field public highlights table<string,table>
 
 -- Ideally this plugin should generate a beautiful tabline a little similar
 -- to what you would get on other editors. The aim is that the default should
@@ -424,7 +425,7 @@ end
 
 ---Generate highlight groups from user
 ---@param user_colors table<string, table>
---- TODO can this become part of a metatable for each highlight group so it is done at the time
+--- TODO: can this become part of a metatable for each highlight group so it is done at the time
 local function add_highlight_groups(user_colors)
   for name, tbl in pairs(user_colors) do
     -- convert 'bufferline_value' to 'BufferlineValue' -> snake to pascal
@@ -434,22 +435,23 @@ local function add_highlight_groups(user_colors)
   end
 end
 
----Keep track of a users config for use throughout the plugin as well as ensuring
----defaults are set
----@param user_config table
----@return table
-function M.set(user_config)
-  user_config = user_config or {}
+--- Merge user config with defaults
+--- @return BufferlineConfig
+function M.apply()
   local defaults = get_defaults()
-  validate_config(user_config, defaults)
-  convert_hl_tables(user_config)
-  --- Store a reference to the original user_config so we can diff what the user set
-  --- this is useful for setting the highlight groups etc. once this has been merged with the
-  --- defaults
-  _user_config = user_config
-  _config = merge(defaults, user_config)
+  validate_config(_user_config, defaults)
+  convert_hl_tables(_user_config)
+  _config = merge(defaults, _user_config)
   add_highlight_groups(_config.highlights)
   return _config
+end
+
+---Keep track of a users config for use throughout the plugin as well as ensuring
+---defaults are set. This is also so we can diff what the user set this is useful
+---for setting the highlight groups etc. once this has been merged with the defaults
+---@param user_config BufferlineConfig
+function M.set(user_config)
+  _user_config = user_config or {}
 end
 
 ---Update highlight colours when the colour scheme changes

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -59,7 +59,7 @@ end
 M.path_sep = vim.loop.os_uname().sysname == "Windows" and "\\" or "/"
 
 -- Source: https://teukka.tech/luanvim.html
-function M.nvim_create_augroups(definitions)
+function M.augroup(definitions)
   for group_name, definition in pairs(definitions) do
     vim.cmd("augroup " .. group_name)
     vim.cmd("autocmd!")

--- a/tests/bufferline_spec.lua
+++ b/tests/bufferline_spec.lua
@@ -14,9 +14,12 @@ describe("Bufferline tests:", function()
   describe("render buffer - ", function()
     it("should create corresponding buffers in state", function()
       bufferline.setup()
+      -- FIXME: vim.v.vim_did_enter is 0 in all test cases.
+      -- figure out how to ensure it is set to 1 instead
+      -- so load should not need to be called manually
+      bufferline.__load()
       local tabline = nvim_bufferline()
       assert.truthy(tabline)
-      assert.equal(tabline, _G.nvim_bufferline())
       assert.is.equal(vim.tbl_count(bufferline._state.buffers), 1)
     end)
 
@@ -27,6 +30,7 @@ describe("Bufferline tests:", function()
           indicator_icon = icon,
         },
       })
+      bufferline.__load()
       local tabline = nvim_bufferline()
       assert.truthy(tabline)
       assert.is_truthy(tabline:match(icon))
@@ -42,6 +46,7 @@ describe("Bufferline tests:", function()
           end,
         },
       })
+      bufferline.__load()
       vim.cmd("edit test.txt")
       local tabline = nvim_bufferline()
       assert.truthy(tabline)
@@ -57,6 +62,7 @@ describe("Bufferline tests:", function()
           left_mouse_command = "vertical sbuffer %d",
         },
       })
+      bufferline.__load()
       bufferline.handle_click(bufnum, "l")
       assert.is_equal(#vim.api.nvim_list_wins(), 2)
     end)
@@ -70,6 +76,7 @@ describe("Bufferline tests:", function()
           end,
         },
       })
+      bufferline.__load()
       bufferline.handle_click(bufnum, "m")
       assert.is_equal(vim.bo[bufnum].filetype, "test")
     end)
@@ -81,6 +88,7 @@ describe("Bufferline tests:", function()
           right_mouse_command = "setfiletype egg",
         },
       })
+      bufferline.__load()
       bufferline.handle_click(bufnum, "r")
       assert.is_equal(vim.bo.filetype, "egg")
     end)
@@ -96,6 +104,7 @@ describe("Bufferline tests:", function()
           end,
         },
       })
+      bufferline.__load()
       bufferline.handle_close_buffer(bufnum)
       assert.is_equal(count, expected)
     end)

--- a/tests/config_spec.lua
+++ b/tests/config_spec.lua
@@ -10,24 +10,26 @@ describe("Config tests", function()
 
   describe("Setting config", function()
     it("should add defaults to user values", function()
-      local under_test = config.set({
+      config.set({
         options = {
           show_close_icon = false,
         },
       })
+      local under_test = config.apply()
       assert.is_false(under_test.options.show_close_icon)
       assert.is_false(vim.tbl_isempty(under_test.highlights))
       assert.is_true(vim.tbl_count(under_test.highlights) > 10)
     end)
 
     it("should create vim highlight groups names for the highlights", function()
-      local under_test = config.set({
+      config.set({
         highlights = {
           fill = {
             guifg = "red",
           },
         },
       })
+      local under_test = config.apply()
 
       assert.equal(under_test.highlights.fill.guifg, "red")
       assert.equal(under_test.highlights.fill.hl_name, "BufferLineFill")
@@ -35,7 +37,8 @@ describe("Config tests", function()
 
     it("should derive colors from the existing highlights", function()
       vim.cmd(fmt("hi Comment guifg=%s", whitesmoke))
-      local under_test = config.set({})
+      config.set({})
+      local under_test = config.apply()
       assert.equal(under_test.highlights.info.guifg, whitesmoke:lower())
     end)
   end)


### PR DESCRIPTION
This PR moves the most expensive parts of the startup logic to a separate function `__load()` to be called after nvim has started. As well as reducing the amount of modules required at startup. This reduces the startup time of the plugin. Not sure yet if this is an unnecessary optimisation, but I'd rather this plugin was as inexpensive to load as possible.

If anyone sees this and wants to try it out, please let me know if it breaks any behaviour. I intend to try it out myself for the next couple of days and merge it if I don't find any issues.