### PR TITLE
feature: add command to select and close a buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,6 +377,7 @@ buffers according to the buffer numbers given by vim.
 
 Bufferline provides _a few_ commands to handle closing buffers visible in the tabline using `BufferLineCloseRight` and `BufferLineCloseLeft`.
 As their names suggest these commands will close all visible buffers to the left or right of the current buffer.
+Another way to close any single buffer is the `BufferLinePickClose` command ([see below](#buffer-pick-functionality)).
 
 ### Sidebar offset
 
@@ -406,6 +407,8 @@ then pick a buffer by typing the character for that specific
 buffer that appears
 
 ![bufferline_pick](https://user-images.githubusercontent.com/22454918/111994691-f2404280-8b0f-11eb-9bc1-6664ccb93154.gif)
+
+Likewise, `BufferLinePickClose` closes the buffer instead of viewing it.
 
 ### Mouse actions
 

--- a/doc/bufferline-lua.txt
+++ b/doc/bufferline-lua.txt
@@ -283,6 +283,15 @@ to a key, e.g. >
 then pick a buffer by typing the character for that specific buffer that
 appears
 
+This functionality can also be used to close a buffer using
+`BufferLinePickClose` by triggering this command the same selection UI will
+appear but on selecting a buffer it will be closed.
+
+this can also be mapped to something like
+>
+  nnoremap <silent> gD :BufferlinePickClose<CR>
+>
+
 ==============================================================================
 MULTIWINDOW MODE                                    *bufferline-lua-multiwindow*
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -52,22 +52,6 @@ function M.restore_positions()
   end
 end
 
-function M.pick_buffer()
-  state.is_picking = true
-  refresh()
-
-  local char = vim.fn.getchar()
-  local letter = vim.fn.nr2char(char)
-  for _, buf in pairs(state.buffers) do
-    if letter == buf.letter then
-      vim.cmd("buffer " .. buf.id)
-    end
-  end
-
-  state.is_picking = false
-  refresh()
-end
-
 ---Handle a user "command" which can be a string or a function
 ---@param command string|function
 ---@param buf_id string
@@ -108,6 +92,36 @@ function M.handle_click(id, button)
   if id then
     handle_user_command(options[cmds[button]], id)
   end
+end
+
+-- Prompts user to select a buffer then applies a function to the buffer
+-- @param func function
+function select_buffer_apply(func)
+  state.is_picking = true
+  refresh()
+
+  local char = vim.fn.getchar()
+  local letter = vim.fn.nr2char(char)
+  for _, buf in pairs(state.buffers) do
+    if letter == buf.letter then
+      func(buf.id)
+    end
+  end
+
+  state.is_picking = false
+  refresh()
+end
+
+function M.pick_buffer()
+  select_buffer_apply(function(buf_id)
+    vim.cmd("buffer " .. buf_id)
+  end)
+end
+
+function M.close_buffer()
+  select_buffer_apply(function(buf_id)
+    M.handle_close_buffer(buf_id)
+  end)
 end
 
 ---@param buffer Buffer
@@ -914,6 +928,7 @@ end
 local function setup_commands()
   local cmds = {
     { name = "BufferLinePick", cmd = "pick_buffer()" },
+    { name = "BufferLineClose", cmd = "close_buffer()" },
     { name = "BufferLineCycleNext", cmd = "cycle(1)" },
     { name = "BufferLineCyclePrev", cmd = "cycle(-1)" },
     { name = "BufferLineCloseRight", cmd = 'close_in_direction("right")' },

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -95,8 +95,8 @@ function M.handle_click(id, button)
 end
 
 -- Prompts user to select a buffer then applies a function to the buffer
--- @param func function
-function select_buffer_apply(func)
+---@param func fun(buf_id: number)
+local function select_buffer_apply(func)
   state.is_picking = true
   refresh()
 
@@ -118,7 +118,7 @@ function M.pick_buffer()
   end)
 end
 
-function M.close_buffer()
+function M.close_buffer_with_pick()
   select_buffer_apply(function(buf_id)
     M.handle_close_buffer(buf_id)
   end)
@@ -928,7 +928,7 @@ end
 local function setup_commands()
   local cmds = {
     { name = "BufferLinePick", cmd = "pick_buffer()" },
-    { name = "BufferLineClose", cmd = "close_buffer()" },
+    { name = "BufferLinePickClose", cmd = "close_buffer_with_pick()" },
     { name = "BufferLineCycleNext", cmd = "cycle(1)" },
     { name = "BufferLineCyclePrev", cmd = "cycle(-1)" },
     { name = "BufferLineCloseRight", cmd = 'close_in_direction("right")' },


### PR DESCRIPTION
This commit adds the functionality requested in #150. Namely,  a command to pick a buffer and close it (similar to BufferLinePick but closes instead of selects). I've also refactored bufferline.pick_buffer() so that both it and the new bufferline.close_buffer() can share the same logic. I've refrained from adding anything to README.md as my writing style would probably clash with @akinsho 's. Also my color scheme is a bit different so pictures would look out of place. I've tried adding a test or two but I couldn't find any tests for bufferline.pick_buffer(), so I could not figure out how to give user input in code.

P.S. this is my first pull request ever, please be gentle.