### PR TITLE
Fix Vimscript usage in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,10 @@ of various highlight groups.
 **Vimscript**
 
 ```vim
+" In your init.lua or init.vim
 set termguicolors
 lua << EOF
-" In your init.lua or init.vim
-lua require("bufferline").setup{}
+require("bufferline").setup{}
 EOF
 ```
 


### PR DESCRIPTION
Hi, a little PR to fix the Vimscript usage in the README:
* The vimscript comment must be outside the lua heredoc, otherwise it triggers an error
* No `lua` keyword required before the `require()` (also triggers an error)

![image](https://user-images.githubusercontent.com/10067226/126476642-616ced0f-3aaf-4f3f-b67d-9a9d6e35bbb7.png)

