### PR TITLE
Refactor: improve get_updated_buffers

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -674,6 +674,7 @@ local function render(bufs, tbs, prefs)
   )
 end
 
+--- sorts buf_names in place, but doesn't add/remove any values
 --- @param buf_nums number[]
 --- @param sorted number[]
 --- @return number[]
@@ -686,10 +687,10 @@ local function get_updated_buffers(buf_nums, sorted)
 
 --- a comparator that sorts buffers by their position in sorted
   local sort_by_sorted = function (buf_id_1, buf_id_2)
-    local buf_1_rank = 1e5 -- assumes no sane person will have this many buffers open
-    local buf_2_rank = 1e5
-    if reverse_lookup_sorted[buf_id_1] then buf_1_rank = reverse_lookup_sorted[buf_id_1] end
-    if reverse_lookup_sorted[buf_id_2] then buf_2_rank = reverse_lookup_sorted[buf_id_2] end
+    local buf_1_rank = reverse_lookup_sorted[buf_id_1]
+    local buf_2_rank = reverse_lookup_sorted[buf_id_2]
+    if not buf_1_rank then return false end
+    if not buf_2_rank then return true end
     return buf_1_rank < buf_2_rank
   end
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -674,7 +674,6 @@ local function render(bufs, tbs, prefs)
   )
 end
 
---- TODO can this be done more efficiently in one loop?
 --- @param buf_nums number[]
 --- @param sorted number[]
 --- @return number[]
@@ -682,21 +681,21 @@ local function get_updated_buffers(buf_nums, sorted)
   if not sorted then
     return buf_nums
   end
-  local updated = {}
-  -- add only buffers from our sort that are (still) in the
-  -- canonical buffer list, maintaining the order
-  for _, b in ipairs(sorted) do
-    if vim.tbl_contains(buf_nums, b) then
-      table.insert(updated, b)
-    end
+
+  local reverse_lookup_sorted = utils.tbl_reverse_lookup(sorted)
+
+--- a comparator that sorts buffers by their position in sorted
+  local sort_by_sorted = function (buf_id_1, buf_id_2)
+    local buf_1_rank = 1e5 -- assumes no sane person will have this many buffers open
+    local buf_2_rank = 1e5
+    if reverse_lookup_sorted[buf_id_1] then buf_1_rank = reverse_lookup_sorted[buf_id_1] end
+    if reverse_lookup_sorted[buf_id_2] then buf_2_rank = reverse_lookup_sorted[buf_id_2] end
+    return buf_1_rank < buf_2_rank
   end
-  -- add any buffers from the buffer list that aren't in our sort
-  for _, b in ipairs(buf_nums) do
-    if not vim.tbl_contains(sorted, b) then
-      table.insert(updated, b)
-    end
-  end
-  return updated
+
+  table.sort(buf_nums, sort_by_sorted)
+
+  return buf_nums
 end
 
 ---Filter the buffers to show based on the user callback passed in

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -59,15 +59,14 @@ end
 --- creates a table whose keys are tbl's values and the value of these keys
 --- is their key in tbl (similar to vim.tbl_add_reverse_lookup)
 --- this assumes that the values in tbl are unique and hashable (no nil/NaN)
---- @param tbl table
---- @return table
+--- @generic K,V
+--- @param tbl table<K,V>
+--- @return table<V,K>
 function M.tbl_reverse_lookup(tbl)
     local ret = {}
-
-    for i, b in pairs(tbl) do
-      ret[b] = i
+    for k, v in pairs(tbl) do
+      ret[v] = k
     end
-
     return ret
 end
 

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -58,13 +58,13 @@ end
 
 --- creates a table whose keys are tbl's values and the value of these keys
 --- is their key in tbl (similar to vim.tbl_add_reverse_lookup)
---- this assumes that the values in tbl are unique
+--- this assumes that the values in tbl are unique and hashable (no nil/NaN)
 --- @param tbl table
 --- @return table
 function M.tbl_reverse_lookup(tbl)
     local ret = {}
 
-    for i, b in ipairs(tbl) do
+    for i, b in pairs(tbl) do
       ret[b] = i
     end
 

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -56,6 +56,21 @@ function M.filter_duplicates(array)
   return res
 end
 
+--- creates a table whose keys are tbl's values and the value of these keys
+--- is their key in tbl (similar to vim.tbl_add_reverse_lookup)
+--- this assumes that the values in tbl are unique
+--- @param tbl table
+--- @return table
+function M.tbl_reverse_lookup(tbl)
+    local ret = {}
+
+    for i, b in ipairs(tbl) do
+      ret[b] = i
+    end
+
+    return ret
+end
+
 M.path_sep = vim.loop.os_uname().sysname == "Windows" and "\\" or "/"
 
 -- Source: https://teukka.tech/luanvim.html


### PR DESCRIPTION
I saw this TODO in the code and thought I could do something about it. The original implementation took quadratic time (O(|sorted|*|buf_nums|)). This one is linear. This makes use of a utility function tbl_reverse_lookup, which is similar to vim.tbl_add_reverse_lookup, except that this one creates a new table instead of modifying the original (this is necessary because the both the keys and the values are numerical, so you can't exchange in place). This implementation reorders buf_nums in place. I've checked the references and they're all in the form of "buf_nums =  get_updated_buffers(buf_nums, sorted)", so I assume it's fine to do it in place. If not, I'm not sure exactly how to shallow copy buf_nums ellegantly (i.e. without a loop) as table.unpack is now depreciated and I'm not sure if there is a current alternative.