### PR TITLE
feat: execute user function against visible buffers

### DIFF
--- a/README.md
+++ b/README.md
@@ -487,6 +487,29 @@ left_mouse_command = function(bufnum)
 end
 ```
 
+### Custom functions
+
+A user can also execute arbitrary functions against a buffer using the
+`buf_exec` function. For example
+
+```lua
+    require('bufferline').buf_exec(
+        4, -- the forth visible buffer from the left
+        user_function -- an arbitrary user function which gets passed the buffer
+    )
+
+    -- e.g.
+    function _G.bdel(num)
+        require('bufferline').buf_exec(num, function(buf, visible_buffers)
+            vim.cmd('bdelete '..buf.id)
+        end
+    end
+
+    vim.cmd [[
+        command -count Bdel <Cmd>lua _G.bdel(<count>)<CR>
+    ]]
+```
+
 ### Custom area
 
 ![custom area](https://user-images.githubusercontent.com/22454918/118527523-4d219f00-b739-11eb-889f-60fb06fd71bc.png)

--- a/README.md
+++ b/README.md
@@ -184,7 +184,6 @@ require('bufferline').setup {
   options = {
     numbers = "none" | "ordinal" | "buffer_id" | "both",
     number_style = "superscript" | "" | { "none", "subscript" }, -- buffer_id at index 1, ordinal at index 2
-    mappings = true | false,
     close_command = "bdelete! %d",       -- can be a string | function, see "Mouse actions"
     right_mouse_command = "bdelete! %d", -- can be a string | function, see "Mouse actions"
     left_mouse_command = "buffer %d",    -- can be a string | function, see "Mouse actions"
@@ -433,6 +432,33 @@ buffer that appears
 ![bufferline_pick](https://user-images.githubusercontent.com/22454918/111994691-f2404280-8b0f-11eb-9bc1-6664ccb93154.gif)
 
 Likewise, `BufferLinePickClose` closes the buffer instead of viewing it.
+
+### `BufferLineGoToBuffer`
+
+You can select a buffer by it's _visible_ position in the bufferline using the `BufferLineGoToBuffer`
+command. This means that if you have 60 buffers open but only 7 visible in the bufferline
+then using `BufferLineGoToBuffer 4` will go to the 4th visible buffer not necessarily the 5 in the
+absolute list of open buffers.
+
+```
+<- (30) | buf31 | buf32 | buf33 | buf34 | buf35 | buf36 | buf37 (24) ->
+```
+
+Using `BufferLineGoToBuffer 4` will open `buf34` as it is the 4th visible buffer.
+
+This can then be mapped using
+
+```vim
+nnoremap <silent><leader>1 <Cmd>BufferLineGoToBuffer 1<CR>
+nnoremap <silent><leader>2 <Cmd>BufferLineGoToBuffer 2<CR>
+nnoremap <silent><leader>3 <Cmd>BufferLineGoToBuffer 3<CR>
+nnoremap <silent><leader>4 <Cmd>BufferLineGoToBuffer 4<CR>
+nnoremap <silent><leader>5 <Cmd>BufferLineGoToBuffer 5<CR>
+nnoremap <silent><leader>6 <Cmd>BufferLineGoToBuffer 6<CR>
+nnoremap <silent><leader>7 <Cmd>BufferLineGoToBuffer 7<CR>
+nnoremap <silent><leader>8 <Cmd>BufferLineGoToBuffer 8<CR>
+nnoremap <silent><leader>9 <Cmd>BufferLineGoToBuffer 9<CR>
+```
 
 ### Mouse actions
 

--- a/doc/bufferline-lua.txt
+++ b/doc/bufferline-lua.txt
@@ -253,7 +253,31 @@ are:
   buffer
 
 ==============================================================================
-SIDEBAR OFFSET                                           *bufferline-lua-offset*
+CUSTOM-FUNCTIONS                                     *bufferline-functions*
+
+A user can also execute arbitrary functions against a buffer using the
+`buf_exec` function. For example
+
+>
+    require('bufferline').buf_exec(
+        4, -- the forth visible buffer from the left
+        user_function -- an arbitrary user function which gets passed the buffer
+    )
+
+    -- e.g.
+    function _G.bdel(num)
+        require('bufferline').buf_exec(num, function(buf, visible_buffers)
+            vim.cmd('bdelete '..buf.id)
+        end
+    end
+
+    vim.cmd [[
+        command -count Bdel <Cmd>lua _G.bdel(<count>)<CR>
+    ]]
+
+
+==============================================================================
+SIDEBAR OFFSET                                           *bufferline-offset*
 
 You can prevent the bufferline drawing above a *vertical* sidebar split such as a file explorer.
 To do this you must set the `offsets` configuration option to a list of tables

--- a/doc/bufferline-lua.txt
+++ b/doc/bufferline-lua.txt
@@ -354,15 +354,38 @@ the `close_command`.
 ==============================================================================
 MAPPINGS                                               *bufferline-lua-mappings*
 
-If the `mappings` option is set to `true`. `<leader>`1-9 mappings will be
-created to navigate the first to the tenth buffer in the bufferline.
+`BufferLineGoToBuffer`
 
-NOTE This is `false` by default.
+You can select a buffer by it's visible position in the bufferline using the `BufferLineGoToBuffer`
+command. This means that if you have 60 buffers open but only 7 visible in the bufferline
+then using `BufferLineGoToBuffer 4` will go to the 4th visible buffer not necessarily the 5 in the
+absolute list of open buffers.
+>
+
+  <- (30) | buf31 | buf32 | buf33 | buf34 | buf35 | buf36 | buf37 (24) ->
+<
+
+Using `BufferLineGoToBuffer 4` will open `buf34` as it is the 4th visible buffer.
+
+This can then be mapped using
+
+>
+  nnoremap <silent><leader>1 <Cmd>BufferLineGoToBuffer 1<CR>
+  nnoremap <silent><leader>2 <Cmd>BufferLineGoToBuffer 2<CR>
+  nnoremap <silent><leader>3 <Cmd>BufferLineGoToBuffer 3<CR>
+  nnoremap <silent><leader>4 <Cmd>BufferLineGoToBuffer 4<CR>
+  nnoremap <silent><leader>5 <Cmd>BufferLineGoToBuffer 5<CR>
+  nnoremap <silent><leader>6 <Cmd>BufferLineGoToBuffer 6<CR>
+  nnoremap <silent><leader>7 <Cmd>BufferLineGoToBuffer 7<CR>
+  nnoremap <silent><leader>8 <Cmd>BufferLineGoToBuffer 8<CR>
+  nnoremap <silent><leader>9 <Cmd>BufferLineGoToBuffer 9<CR>
+<
 
 If you'd rather map these yourself, use:
 
 `vim nnoremap mymap :lua require"bufferline".go_to_buffer(num)<CR>`
-You can close buffers by clicking the close icon or by _right clicking_ the tab anywhere
+
+You can close buffers by clicking the close icon or by right clicking the tab anywhere
 
 
 A few of this plugins commands can be mapped for ease of use. >

--- a/doc/bufferline-lua.txt
+++ b/doc/bufferline-lua.txt
@@ -1,30 +1,31 @@
-*nvim-bufferline.lua*   For Neovim version 0.5+   Last change: 2021 January 19
+*nvim-bufferline.lua*   For Neovim version 0.5+   Last change: 2021 August 20
 
 A snazzy bufferline for neovim written in lua
 
 Author: Akin Sowemimo
 
 ==============================================================================
-CONTENTS                                      *bufferline-lua*
-*bufferline-lua-contents*
+CONTENTS                                      *bufferline*
+*bufferline-contents*
 
-Introduction...........................: |bufferline-lua-introduction|
-Usage..................................: |bufferline-lua-usage|
-Settings...............................: |bufferline-lua-settings|
-LSP Diagnostics........................: |bufferline-lua-diagnostics|
-Sorting................................: |bufferline-lua-sorting|
-Filtering..............................: |bufferline-lua-filtering|
-Commands...............................: |bufferline-lua-commands|
-Pick...................................: |bufferline-lua-pick|
-Multi-window...........................: |bufferline-lua-multiwindow|
-Mappings...............................: |bufferline-lua-mapping|
-Highlights.............................: |bufferline-lua-highlights|
-Mouse actions..........................: |bufferline-lua-mouse-actions|
-Issues.................................: |bufferline-lua-issues|
+Introduction...........................: |bufferline-introduction|
+Usage..................................: |bufferline-usage|
+Settings...............................: |bufferline-settings|
+LSP Diagnostics........................: |bufferline-diagnostics|
+Sorting................................: |bufferline-sorting|
+Filtering..............................: |bufferline-filtering|
+Commands...............................: |bufferline-commands|
+Custom functions.......................: |bufferline-exec|
+Pick...................................: |bufferline-pick|
+Multi-window...........................: |bufferline-multiwindow|
+Mappings...............................: |bufferline-mapping|
+Highlights.............................: |bufferline-highlights|
+Mouse actions..........................: |bufferline-mouse-actions|
+Issues.................................: |bufferline-issues|
 
 
 ==============================================================================
-INTRODUCTION				        *bufferline-lua-introduction*
+INTRODUCTION				        *bufferline-introduction*
 
 A _snazzy_ 💅 buffer line (with minimal tab integration) for Neovim built
 using `lua`.
@@ -35,7 +36,7 @@ centaur tabs (https://github.com/ema2159/centaur-tabs). I don't intend to copy
 all of it's functionality though.
 
 ==============================================================================
-USAGE						        *bufferline-lua-usage*
+USAGE						        *bufferline-usage*
 You need to be using `termguicolors` for this plugin to work, as it reads the
 hex `gui` color values of various highlight groups. >
 
@@ -44,7 +45,7 @@ hex `gui` color values of various highlight groups. >
     lua require"bufferline".setup{}
 <
 ==============================================================================
-SETTINGS					     *bufferline-lua-settings*
+SETTINGS					     *bufferline-settings*
 
 The available settings are: >
 
@@ -113,7 +114,7 @@ You can change the appearance of the bufferline separators by setting the
   second is the right separator
 
 ==============================================================================
-LSP DIAGNOSTICS					    *bufferline-lua-diagnostics*
+LSP DIAGNOSTICS					    *bufferline-diagnostics*
 
 By setting `diagnostics = "nvim_lsp"` you will get an indicator in the
 bufferline for a given tab if it has any errors This will allow you to
@@ -143,7 +144,7 @@ replacing the highlights for `error`, `error_visible`, `error_selected`,
 `warning`, `warning_visible`, `warning_selected`.
 
 ==============================================================================
-REGULAR TAB SIZES                                  *bufferline-lua-regular-tabs*
+REGULAR TAB SIZES                                  *bufferline-regular-tabs*
 
 Generally this plugin enforces a minimum tab size so that the buffer line
 appears consistent. Where a tab is smaller than the tab size it is padded.
@@ -156,7 +157,7 @@ NOTE: when this option is set to `true`. It will disable the ability to
 deduplicate buffers.
 
 ==============================================================================
-SORTING					               *bufferline-lua-sorting*
+SORTING					               *bufferline-sorting*
 
 Bufferline allows you to sort the visible buffers by `extension` or `directory`: >
 
@@ -191,7 +192,7 @@ traverse the bufferline bufferlist in order whereas `bnext` and `bprev` will
 cycle buffers according to the buffer numbers given by vim.
 
 ==============================================================================
-FILTERING                                           *bufferline-lua-filtering*
+FILTERING                                           *bufferline-filtering*
 
 Bufferline can be configured to take a custom filtering function via the
 `custom_filter` option. This value must be a lua function that will receive
@@ -242,7 +243,7 @@ For example: >
 <
 
 ==============================================================================
-COMMANDS                                               *bufferline-lua-commands*
+COMMANDS                                               *bufferline-commands*
 
 Bufferline includes a few commands to allow deleting buffers. These commands
 are:
@@ -315,7 +316,7 @@ amount the bufferline is offset beyond just the window width, this isn't
 something that is generally required though.
 
 ==============================================================================
-BUFFERLINE PICK                                            *bufferline-lua-pick*
+BUFFERLINE PICK                                            *bufferline-pick*
 
 Using the `BufferLinePick` command will allow for easy selection of a buffer
 in view. Trigger the command, using `:BufferLinePick` or better still map this
@@ -336,15 +337,7 @@ this can also be mapped to something like
 >
 
 ==============================================================================
-MULTIWINDOW MODE                                    *bufferline-lua-multiwindow*
-
-When this mode is active, for layouts of multiple windows in the tabpage, only
-the buffers that are displayed in those windows are listed in the tabline.
-That only applies to multi-window layouts, if there is only one window in the
-tabpage, all buffers are listed.
-
-==============================================================================
-MOUSE ACTIONS                                     *bufferline-lua-mouse-actions*
+MOUSE ACTIONS                                     *bufferline-mouse-actions*
 
 You can configure different type of mouse clicks to behave differently. The
 current mouse click types are
@@ -376,7 +369,7 @@ the `close_command`.
 <
 
 ==============================================================================
-MAPPINGS                                               *bufferline-lua-mappings*
+MAPPINGS                                               *bufferline-mappings*
 
 `BufferLineGoToBuffer`
 
@@ -430,7 +423,7 @@ A few of this plugins commands can be mapped for ease of use. >
     nnoremap <silent><mymap> :lua require'bufferline'.sort_buffers_by(function (buf_a, buf_b) return buf_a.id < buf_b.id end)<CR>
 <
 ==============================================================================
-HIGHLIGHTS                                           *bufferline-lua-highlights*
+HIGHLIGHTS                                           *bufferline-highlights*
 
 This plugin is designed to work automatically, deriving colours from the
 user's theme, you can change highlight groups by overriding the section you'd
@@ -671,7 +664,7 @@ highlight command. See `:h highlight` .
 <
 
 ==============================================================================
-ISSUES							*bufferline-lua-issues*
+ISSUES							*bufferline-issues*
 
 Please raise any issues you encounter whilst using this plugin at:
 https://github.com/akinsho/nvim-bufferline.lua/issues

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -528,7 +528,7 @@ local function render_buffer(preferences, buffer)
   --- @param index number
   --- @param num_of_bufs number
   --- @returns string
-  local fn = function(index, num_of_bufs)
+  local function render_fn(index, num_of_bufs)
     if left_sep then
       buffer_component = left_sep .. buffer_component .. right_sep
     elseif index < num_of_bufs then
@@ -537,7 +537,7 @@ local function render_buffer(preferences, buffer)
     return buffer_component
   end
 
-  return fn, ctx.length
+  return render_fn, ctx.length
 end
 
 ---@param icon string

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -22,6 +22,8 @@ local state = {
   is_picking = false,
   ---@type Buffer[]
   buffers = {},
+  ---@type Buffer[]
+  visible_buffers = {},
   current_letters = {},
   custom_sort = nil,
 }
@@ -91,6 +93,16 @@ function M.handle_click(id, button)
   }
   if id then
     handle_user_command(options[cmds[button]], id)
+  end
+end
+
+---Execute an arbitrary user function on a visible by it's position buffer
+---@param index number
+---@param func fun(num: number)
+function M.buf_exec(index, func)
+  local target = state.visible_buffers[index]
+  if target and type(func) == "function" then
+    func(target, state.visible_buffers)
   end
 end
 
@@ -563,16 +575,22 @@ local function truncation_component(count, icon, hls)
   return utils.join(hls.fill.hl, padding, count, padding, icon, padding)
 end
 
---[[
-PREREQUISITE: active buffer always remains in view
-1. Find amount of available space in the window
-2. Find the amount of space the bufferline will take up
-3. If the bufferline will be too long remove one tab from the before or after
-section
-4. Re-check the size, if still too long truncate recursively till it fits
-5. Add the number of truncated buffers as an indicator
---]]
-local function truncate(before, current, after, available_width, marker)
+--- PREREQUISITE: active buffer always remains in view
+--- 1. Find amount of available space in the window
+--- 2. Find the amount of space the bufferline will take up
+--- 3. If the bufferline will be too long remove one tab from the before or after
+--- section
+--- 4. Re-check the size, if still too long truncate recursively till it fits
+--- 5. Add the number of truncated buffers as an indicator
+---@param before Buffers
+---@param current Buffers
+---@param after Buffers
+---@param available_width number
+---@param marker table
+---@return string
+---@return table
+---@return Buffer[]
+local function truncate(before, current, after, available_width, marker, visible)
   local line = ""
 
   local left_trunc_marker = get_marker_size(marker.left_count, marker.left_element_size)
@@ -583,17 +601,16 @@ local function truncate(before, current, after, available_width, marker)
   local total_length = before.length + current.length + after.length + markers_length
 
   if available_width >= total_length then
+    visible = utils.array_concat(before.buffers, current.buffers, after.buffers)
+    for index, buf in ipairs(visible) do
+      line = line .. buf.component(index, #visible)
+    end
+    return line, marker, visible
     -- if we aren't even able to fit the current buffer into the
     -- available space that means the window is really narrow
     -- so don't show anything
-    -- Merge all the buffers and render the components
-    local bufs = utils.array_concat(before.buffers, current.buffers, after.buffers)
-    for index, buf in ipairs(bufs) do
-      line = line .. buf.component(index, #bufs)
-    end
-    return line, marker
   elseif available_width < current.length then
-    return "", marker
+    return "", marker, visible
   else
     if before.length >= after.length then
       before:drop(1)
@@ -610,7 +627,7 @@ local function truncate(before, current, after, available_width, marker)
       marker.left_count = 0
       marker.right_count = 0
     end
-    return truncate(before, current, after, available_width, marker), marker
+    return truncate(before, current, after, available_width, marker, visible)
   end
 end
 
@@ -660,12 +677,14 @@ local function render(bufs, tbs, prefs)
     - close_length
 
   local before, current, after = get_sections(bufs)
-  local line, marker = truncate(before, current, after, available_width, {
+  local line, marker, visible_buffers = truncate(before, current, after, available_width, {
     left_count = 0,
     right_count = 0,
     left_element_size = left_element_size,
     right_element_size = right_element_size,
   })
+
+  state.visible_buffers = visible_buffers
 
   if marker.left_count > 0 then
     local icon = truncation_component(marker.left_count, left_trunc_icon, hl)
@@ -785,12 +804,12 @@ local function bufferline(preferences)
   return render(state.buffers, all_tabs, preferences)
 end
 
+--- Open a buffer based on it's visible position in the list
 ---@param num number
 function M.go_to_buffer(num)
-  local buf_nums = get_buffers_by_mode()
-  buf_nums = get_updated_buffers(buf_nums, state.custom_sort)
-  if num <= #buf_nums then
-    vim.cmd("buffer " .. buf_nums[num])
+  local buf = state.visible_buffers[num]
+  if buf then
+    vim.cmd("buffer " .. buf.id)
   end
 end
 
@@ -937,10 +956,6 @@ end
 
 ---@param preferences BufferlineConfig
 local function setup_mappings(preferences)
-  -- TODO: / idea: consider allowing these mappings to open buffers based on their
-  -- visual position i.e. <leader>1 maps to the first visible buffer regardless
-  -- of it actual ordinal number i.e. position in the full list or it's actual
-  -- buffer id
   if preferences.options.mappings then
     for i = 1, 9 do
       api.nvim_set_keymap(

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -982,7 +982,6 @@ local function setup_commands()
     { name = "BufferLineSortByDirectory", cmd = 'sort_buffers_by("directory")' },
     { name = "BufferLineSortByRelativeDirectory", cmd = 'sort_buffers_by("relative_directory")' },
     { name = "BufferLineSortByTabs", cmd = 'sort_buffers_by("tabs")' },
-    -- { name = "BufferLineBufExec", count = true, cmd = 'buf_exec(v:count, )'}
   }
   for _, cmd in ipairs(cmds) do
     vim.cmd(fmt('command! %s lua require("bufferline").%s', cmd.name, cmd.cmd))

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -954,20 +954,6 @@ local function setup_autocommands(preferences)
   utils.augroup({ BufferlineColors = autocommands })
 end
 
----@param preferences BufferlineConfig
-local function setup_mappings(preferences)
-  if preferences.options.mappings then
-    for i = 1, 9 do
-      api.nvim_set_keymap(
-        "n",
-        "<leader>" .. i,
-        ':lua require"bufferline".go_to_buffer(' .. i .. ")<CR>",
-        { silent = true, nowait = true, noremap = true }
-      )
-    end
-  end
-end
-
 local function setup_commands()
   local cmds = {
     { name = "BufferLinePick", cmd = "pick_buffer()" },
@@ -999,9 +985,8 @@ function M.__load()
   local preferences = config.apply()
   -- on loading (and reloading) the plugin's config reset all the highlights
   require("bufferline.highlights").set_all(preferences.highlights)
-  -- TODO: don't reapply commands,mappings and autocommands if load has already been called
+  -- TODO: don't reapply commands and autocommands if load has already been called
   setup_commands()
-  setup_mappings(preferences)
   setup_autocommands(preferences)
   vim.o.tabline = "%!v:lua.nvim_bufferline()"
   M.toggle_bufferline()

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -805,11 +805,16 @@ local function bufferline(preferences)
 end
 
 --- Open a buffer based on it's visible position in the list
----@param num number
-function M.go_to_buffer(num)
-  local buf = state.visible_buffers[num]
+--- unless absolute is specified in which case this will open it based on it place in the full list
+--- this is significantly less helpful if you have a lot of buffers open
+---@param num number | string
+---@param absolute boolean whether or not to use the buffers absolute position or visible positions
+function M.go_to_buffer(num, absolute)
+  num = type(num) == "string" and tonumber(num) or num
+  local list = absolute and state.buffers or state.visible_buffers
+  local buf = list[num]
   if buf then
-    vim.cmd("buffer " .. buf.id)
+    vim.cmd(fmt("buffer %d", buf.id))
   end
 end
 
@@ -968,9 +973,11 @@ local function setup_commands()
     { name = "BufferLineSortByDirectory", cmd = 'sort_buffers_by("directory")' },
     { name = "BufferLineSortByRelativeDirectory", cmd = 'sort_buffers_by("relative_directory")' },
     { name = "BufferLineSortByTabs", cmd = 'sort_buffers_by("tabs")' },
+    { name = "BufferLineGoToBuffer", cmd = "go_to_buffer(<q-args>)", nargs = 1 },
   }
   for _, cmd in ipairs(cmds) do
-    vim.cmd(fmt('command! %s lua require("bufferline").%s', cmd.name, cmd.cmd))
+    local nargs = cmd.nargs and fmt("-nargs=%d", cmd.nargs) or ""
+    vim.cmd(fmt('command! %s %s lua require("bufferline").%s', nargs, cmd.name, cmd.cmd))
   end
 end
 

--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -982,6 +982,7 @@ local function setup_commands()
     { name = "BufferLineSortByDirectory", cmd = 'sort_buffers_by("directory")' },
     { name = "BufferLineSortByRelativeDirectory", cmd = 'sort_buffers_by("relative_directory")' },
     { name = "BufferLineSortByTabs", cmd = 'sort_buffers_by("tabs")' },
+    -- { name = "BufferLineBufExec", count = true, cmd = 'buf_exec(v:count, )'}
   }
   for _, cmd in ipairs(cmds) do
     vim.cmd(fmt('command! %s lua require("bufferline").%s', cmd.name, cmd.cmd))

--- a/lua/bufferline/buffers.lua
+++ b/lua/bufferline/buffers.lua
@@ -37,6 +37,7 @@ end
 ---@field public modifiable boolean
 ---@field public buftype string
 ---@field public letter string
+---@field public ordinal number
 M.Buffer = {}
 
 ---create a new buffer class

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -21,7 +21,7 @@ local _user_config = {}
 ---@field public name_formatter fun(path: string):string
 ---@field public tab_size number
 ---@field public max_name_length number
----@field public mappings boolean
+---@field public mappings boolean DEPRECATED
 ---@field public show_buffer_icons boolean
 ---@field public show_buffer_close_icons boolean
 ---@field public show_close_icon boolean
@@ -36,10 +36,19 @@ local _user_config = {}
 ---@field public offsets table[]
 
 ---Ensure the user has only specified highlight groups that exist
----@param prefs table
----@param defaults table
+---@param prefs BufferlineConfig
+---@param defaults BufferlineConfig
 local function validate_config(prefs, defaults)
-  if prefs and prefs.highlights then
+  if not prefs then
+    return
+  end
+  if prefs.options and prefs.options.mappings then
+    vim.notify(
+      "'mappings' has been deprecated please refer to the BufferLineGoToBuffer section of the README",
+      vim.log.levels.WARN
+    )
+  end
+  if prefs.highlights then
     local incorrect = {}
     for k, _ in pairs(prefs.highlights) do
       if not defaults.highlights[k] then
@@ -83,7 +92,10 @@ local function convert_hl_tables(prefs)
           })
         else
           prefs.highlights[hl][attribute] = nil
-          print(string.format("removing %s as it is not formatted correctly", hl))
+          require("bufferline.utils").echomsg(
+            string.format("removing %s as it is not formatted correctly", hl),
+            "WarningMsg"
+          )
         end
       end
     end

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -26,6 +26,9 @@ end
 -- parameters have their values shallow-copied to the final array.
 -- Note that userdata and function values are treated as scalar.
 -- https://stackoverflow.com/questions/1410862/concatenation-of-tables-in-lua
+--- @generic T
+--- @vararg `T`
+--- @return T[]
 function M.array_concat(...)
   local t = {}
   for n = 1, select("#", ...) do

--- a/lua/bufferline/utils.lua
+++ b/lua/bufferline/utils.lua
@@ -27,7 +27,7 @@ end
 -- Note that userdata and function values are treated as scalar.
 -- https://stackoverflow.com/questions/1410862/concatenation-of-tables-in-lua
 --- @generic T
---- @vararg `T`
+--- @vararg any
 --- @return T[]
 function M.array_concat(...)
   local t = {}


### PR DESCRIPTION
This PR adds the ability to operate on bufferline buffers based on their visual position in the bufferline rather than their absolute position

```lua
require'bufferline'.buf_exec(
 4, -- the forth visible buffer from the left
 user_function -- an arbitrary user function which gets passed the buffer
)

-- e.g.
require'bufferline'.buf_exec(2, function(buf)
 vim.cmd('bdelete '..buf.id)
end
```
This also refactors the `<leader>0-9` mappings to operate on the visible buffers rather than their absolute positions in the list so 2 will open the 3rd visible buffer in a hypothetical list of 20 not necessarily the 2nd which might not be currently visible