### PR TITLE
fix: truncate multibyte characters by cell

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -216,6 +216,24 @@ local function get_buffers_by_mode(mode)
   return utils.get_valid_buffers()
 end
 
+-- truncate a string based on number of display columns/cells it occupies
+-- so that multibyte characters are not broken up mid character
+---@param str string
+---@param col_limit number
+---@return string
+local function truncate_by_cell(str, col_limit)
+  if str and str:len() == strwidth(str) then
+    return fn.strcharpart(str, 0, col_limit)
+  end
+  local short = fn.strcharpart(str, 0, col_limit)
+  if api.nvim_strwidth(short) > col_limit then
+    while api.nvim_strwidth(short) > col_limit do
+      short = fn.strcharpart(short, 0, fn.strchars(short) - 1)
+    end
+  end
+  return short
+end
+
 local function truncate_filename(filename, word_limit)
   local trunc_symbol = "…"
   if api.nvim_strwidth(filename) <= word_limit then
@@ -226,9 +244,8 @@ local function truncate_filename(filename, word_limit)
   local without_prefix = fn.fnamemodify(filename, ":t:r")
   if api.nvim_strwidth(without_prefix) < word_limit then
     return without_prefix .. trunc_symbol
-  else
-    return fn.strcharpart(filename, 0, word_limit - 1) .. trunc_symbol
   end
+  return truncate_by_cell(filename, word_limit - 1) .. trunc_symbol
 end
 
 --- @param buffer Buffer


### PR DESCRIPTION
This PR adds trunctation of multibyte strings by cell/column rather than by byte, only if the byte count of a string does not match display size i.e. if it contains multibyte characters

@alohaia can you try this PR and see if it fixes #177 