### PR TITLE
fix: respect 'insert_after_current' and 'insert_at_end' after a custom sort is set

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -54,16 +54,10 @@ local function bufferline()
   local is_tabline = config:is_tabline()
   local components = is_tabline and tabpages.get_components(state) or buffers.get_components(state)
 
-  -- NOTE: keep track of the previous state so it can be used for sorting
-  -- specifically to position newly opened buffers next to the buffer that was previously open
-  local prev_idx, prev_components = state.current_element_index, state.components
-
   local function sorter(list)
-    return sorters.sort(list, {
-      current_index = prev_idx,
-      prev_components = prev_components,
-      custom_sort = state.custom_sort,
-    })
+    -- the user has manually sorted the buffers don't try to re-sort them
+    if state.custom_sort then return list end
+    return sorters.sort(list)
   end
 
   local _, current_idx = utils.find(function(component) return component:current() end, components)

--- a/lua/bufferline/commands.lua
+++ b/lua/bufferline/commands.lua
@@ -8,24 +8,12 @@ local utils = lazy.require("bufferline.utils") ---@module "bufferline.utils"
 local config = lazy.require("bufferline.config") ---@module "bufferline.config"
 local groups = lazy.require("bufferline.groups") ---@module "bufferline.groups"
 local sorters = lazy.require("bufferline.sorters") ---@module "bufferline.sorters"
-local constants = lazy.require("bufferline.constants") ---@module "bufferline.constants"
 local pick = lazy.require("bufferline.pick") ---@module "bufferline.pick"
 
 local M = {}
 
-local positions_key = constants.positions_key
-
 local fmt = string.format
 local api = vim.api
-
----@param ids number[]
-local function save_positions(ids) vim.g[positions_key] = table.concat(ids, ",") end
-
---- @param elements bufferline.TabElement[]
---- @return number[]
-local function get_ids(elements)
-  return vim.tbl_map(function(item) return item.id end, elements)
-end
 
 --- open the current element
 ---@param id number
@@ -170,9 +158,9 @@ function M.move_to(to_index, from_index)
     local destination_buf = state.components[next_index]
     state.components[next_index] = item
     state.components[index] = destination_buf
-    state.custom_sort = get_ids(state.components)
+    state.custom_sort = utils.get_ids(state.components)
     local opts = config.options
-    if opts.persist_buffer_sort then save_positions(state.custom_sort) end
+    if opts.persist_buffer_sort then utils.save_positions(state.custom_sort) end
     ui.refresh()
   end
 end
@@ -268,10 +256,10 @@ end
 --- @param sort_by (string|function)?
 function M.sort_by(sort_by)
   if next(state.components) == nil then return utils.notify("Unable to find elements to sort, sorry", "warn") end
-  sorters.sort(state.components, { sort_by = sort_by })
-  state.custom_sort = get_ids(state.components)
+  sorters.sort(state.components, sort_by)
+  state.custom_sort = utils.get_ids(state.components)
   local opts = config.options
-  if opts.persist_buffer_sort then save_positions(state.custom_sort) end
+  if opts.persist_buffer_sort then utils.save_positions(state.custom_sort) end
   ui.refresh()
 end
 

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -196,14 +196,6 @@ end
 
 function Buffer:current() return api.nvim_get_current_buf() == self.id end
 
---- If the buffer is already part of state then it is existing
---- otherwise it is new
----@param components bufferline.TabElement[]
----@return boolean
-function Buffer:previously_opened(components)
-  return utils.find(function(component) return component.id == self.id end, components) ~= nil
-end
-
 --- Find and return the index of the matching buffer (by id) in the list in state
 ---@param components bufferline.TabElement[]
 function Buffer:find_index(components)
@@ -211,9 +203,6 @@ function Buffer:find_index(components)
     if component.id == self.id then return index end
   end
 end
-
----@param components bufferline.TabElement[]
-function Buffer:newly_opened(components) return not self:previously_opened(components) end
 
 function Buffer:visible() return fn.bufwinnr(self.id) > 0 end
 

--- a/lua/bufferline/sorters.lua
+++ b/lua/bufferline/sorters.lua
@@ -78,55 +78,13 @@ local function sort_by_tabs(a, b)
   return buf_a_tabnr < buf_b_tabnr
 end
 
----@param components bufferline.TabElement[]
----@return bufferline.Sorter
-local sort_by_new_after_existing = function(components)
-  return function(item_a, item_b)
-    if item_a:newly_opened(components) and item_b:previously_opened(components) then
-      return false
-    elseif item_a:previously_opened(components) and item_b:newly_opened(components) then
-      return true
-    end
-    return item_a.id < item_b.id
-  end
-end
-
----@param prev_components bufferline.TabElement[]
----@return bufferline.Sorter
-local sort_by_new_after_current = function(prev_components, current_index)
-  return function(item_a, item_b)
-    local a_index = item_a:find_index(prev_components)
-    local a_is_new = item_a:newly_opened(prev_components)
-    local b_index = item_b:find_index(prev_components)
-    local b_is_new = item_b:newly_opened(prev_components)
-    current_index = current_index or 1
-    if not a_is_new and not b_is_new then
-      -- If both buffers are either before or after (inclusive) the current buffer, respect the current order.
-      if (a_index - current_index) * (b_index - current_index) >= 0 then return a_index < b_index end
-      return a_index < current_index
-    elseif not a_is_new and b_is_new then
-      return a_index <= current_index
-    elseif a_is_new and not b_is_new then
-      return current_index < b_index
-    end
-    return item_a.id < item_b.id
-  end
-end
-
 --- sorts a list of buffers in place
 --- @param elements bufferline.TabElement[]
---- @param opts bufferline.SorterOptions
-function M.sort(elements, opts)
-  opts = opts or {}
-  local sort_by = opts.sort_by or config.options.sort_by
-  -- the user has manually sorted the buffers don't try to re-sort them
-  if opts.custom_sort then return elements end
+--- @param sort_by (string|function)?
+function M.sort(elements, sort_by)
+  sort_by = sort_by or config.options.sort_by
   if sort_by == "none" then
     return elements
-  elseif sort_by == "insert_after_current" then
-    table.sort(elements, sort_by_new_after_current(opts.prev_components, opts.current_index))
-  elseif sort_by == "insert_at_end" then
-    table.sort(elements, sort_by_new_after_existing(opts.prev_components))
   elseif sort_by == "extension" then
     table.sort(elements, sort_by_extension)
   elseif sort_by == "directory" then

--- a/lua/bufferline/types.lua
+++ b/lua/bufferline/types.lua
@@ -157,8 +157,6 @@
 ---@field public ancestor bufferline.AncestorSearch
 ---@field public __ancestor bufferline.AncestorSearch
 ---@field public find_index fun(Buffer, BufferlineState): integer?
----@field public newly_opened fun(Buffer, BufferlineState): boolean
----@field public previously_opened fun(Buffer, BufferlineState): boolean
 
 ---@alias bufferline.ComponentsByGroup (bufferline.Group | bufferline.Component[])[]
 
@@ -221,9 +219,3 @@
 ---@field right_offset_size number
 
 ---@alias bufferline.Sorter fun(buf_a: bufferline.Buffer, buf_b: bufferline.Buffer): boolean
-
----@class bufferline.SorterOptions
----@field sort_by (string|function)?
----@field current_index integer?
----@field custom_sort boolean?
----@field prev_components bufferline.TabElement[]

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -154,6 +154,17 @@ function M.notify(msg, level, opts)
   vim.schedule(function() vim.notify(msg, level, nopts) end)
 end
 
+local positions_key = constants.positions_key
+
+---@param ids number[]
+function M.save_positions(ids) vim.g[positions_key] = table.concat(ids, ",") end
+
+--- @param elements bufferline.TabElement[]
+--- @return number[]
+function M.get_ids(elements)
+  return vim.tbl_map(function(item) return item.id end, elements)
+end
+
 ---Get an icon for a filetype using either nvim-web-devicons or vim-devicons
 ---if using the lua plugin this also returns the icon's highlights
 ---@param opts bufferline.IconFetcherOpts


### PR DESCRIPTION
This PR fixes two issues related to behaviour with a custom buffer sort order that have been bothering me for a while.

As described in #706, if `sort_by` is `"insert_after_current"` or `"insert_at_end"`, and you move a buffer manually using `:BufferLineMoveNext` or `:BufferLineMovePrev`, new buffers are no longer inserted after the current buffer or at the end, but rather based on their ID.
This fixes this by moving the logic out of the `sort` function, and into what was the `get_updated_buffers` function. There, while sorting the buffers according to the order in `custom_sort`, it will also ensure that new buffers (ie those that do not appear in `custom_sort`) are put where they should be. It then updates `custom_sort` to now contain those new buffers.

~~The second issue is that restoring the custom sort order from a saved session didn't work correctly most of the time, because it was storing buffer ids which are not preserved by `:mksession`. The fix is to store the full paths of the buffers in `g:BufferlinePositions` instead. `vim.json` is required to stringify the list as `:mksession` only stores string/number values.~~

This is the first time I've done anything substantial with a Neovim plugin, so I apologise if I've done something very wrong. I've only really tested this in my own setup, and I haven't done anything to the tests, because I don't really know how all that works. Feel free to make any changes you think are needed.