### PR TITLE
feat(number): add number options for visible buffer id

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,8 +249,8 @@ see `:help bufferline-groups` for more information on how to set these up
 
 ![bufferline with numbers](https://user-images.githubusercontent.com/22454918/119562833-b5f2c200-bd9e-11eb-81d3-06876024bf30.png)
 
-You can prefix buffer names with either the `ordinal` or `buffer id`, using the `numbers` option.
-Currently this can be specified as either a string of `buffer_id` | `ordinal` or a function
+You can prefix buffer names with either the `ordinal` or `buffer id` or `visible`, using the `numbers` option.
+Currently this can be specified as either a string of `buffer_id` | `ordinal` | `visible` or a function
 
 ![numbers](https://user-images.githubusercontent.com/22454918/130784872-936d4c55-b9dd-413b-871d-7bc66caf8f17.png)
 

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -266,9 +266,9 @@ e.g.
 ==============================================================================
 NUMBERS                                                    *bufferline-numbers*
 
-You can prefix buffer names with either the `ordinal` or `buffer id`, using
+You can prefix buffer names with either the `ordinal` or `buffer id` or `visible`, using
 the `numbers` option. Currently this can be specified as either a string of
-`buffer_id` | `ordinal` or a function This function allows maximum flexibility
+`buffer_id` | `ordinal` | `visible` or a function This function allows maximum flexibility
 in determining the appearance of this section.
 
 It is passed a table with the following keys:

--- a/lua/bufferline/numbers.lua
+++ b/lua/bufferline/numbers.lua
@@ -1,4 +1,6 @@
 local config = require("bufferline.config")
+local lazy = require("bufferline.lazy")
+local state = lazy.require("bufferline.state") ---@module "bufferline.state"
 
 ---@class NumbersFuncOpts
 ---@field ordinal number
@@ -61,6 +63,27 @@ end
 
 local lower, raise = to_style(subscript_numbers), to_style(superscript_numbers)
 
+--- Get the visible index of a tab using bufferline.state
+---@param tab_element bufferline.TabElement The tab element to find
+---@return integer|nil The visible index (1-based) or nil if not found
+local function get_visible_index_from_state(tab_element)
+  local visible_tabs = state.visible_components -- Get the visible components list
+
+  if not visible_tabs or type(visible_tabs) ~= "table" then
+    return nil
+  end
+
+  -- Find the index of the tab_element in the visible tabs
+  for index, element in ipairs(visible_tabs) do
+    if element.id == tab_element.id then
+      return index
+    end
+  end
+
+  return nil
+end
+
+
 ---Add a number prefix to the buffer matching a user's preference
 ---@param buffer bufferline.TabElement
 ---@param numbers numbers_opt
@@ -79,7 +102,13 @@ local function prefix(buffer, numbers)
   -- buffer_id at top left and ordinal number at bottom right
   if numbers == "both" then return construct_number(buffer.id) .. construct_number(buffer.ordinal, maps.subscript) end
 
-  return construct_number(numbers == "ordinal" and buffer.ordinal or buffer.id)
+  if numbers == "ordinal" then
+    return construct_number(buffer.ordinal)
+  elseif numbers == "visible" then
+    return construct_number(get_visible_index_from_state(buffer) or buffer.id)
+  else
+    return construct_number(buffer.id)
+  end
 end
 
 --- @param context bufferline.RenderContext


### PR DESCRIPTION
related to #987

Add option `visible` to display the visible id of the buffer,
it's pretty helpful to combine with `go_to` buffer functions