### PR TITLE
color_icons=false respects user set highlights

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -134,7 +134,7 @@ The available configuration are:
                     separator = true
                 }
             },
-            color_icons = true | false, -- whether or not to add the filetype icon highlights
+            color_icons = true | false, -- whether to use filetype native colors or theme highlights
             get_element_icon = function(element)
               -- element consists of {filetype: string, path: string, extension: string, directory: string}
               -- This can be used to change how bufferline fetches the icon

--- a/lua/bufferline/highlights.lua
+++ b/lua/bufferline/highlights.lua
@@ -105,7 +105,7 @@ function M.set_icon_highlight(state, hls, base_hl)
   if icon_hl_cache[icon_hl] then return icon_hl end
 
   local color_icons = config.options.color_icons
-  local color = not color_icons and "NONE"
+  local color = not color_icons and parent.fg or nil
   local hl_colors = vim.tbl_extend("force", parent, {
     fg = color or colors.get_color({ name = base_hl, attribute = "fg" }),
     ctermfg = color or colors.get_color({ name = base_hl, attribute = "fg", cterm = true }),


### PR DESCRIPTION
`color_icons = false` was ignoring user-set highlights (defaulting to "NONE" rather than inheriting the fg color the same way bg is inherited).

This (extremely simple) PR fixes that. I kind of wish I could've just submitted a patch instead of a whole PR.