### PR TITLE
Adds an "always" option to "show_tab_indicators" to show the tab indicators even if there is only 1 tab

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -149,7 +149,7 @@ The available configuration are:
             show_buffer_icons = true | false, -- disable filetype icons for buffers
             show_buffer_close_icons = true | false,
             show_close_icon = true | false,
-            show_tab_indicators = true | false,
+            show_tab_indicators = true | false | "always", -- shows tab indicators ('always' will show tab indicators even if there is only 1)
             show_duplicate_prefix = true | false, -- whether to show duplicate buffer prefix
             duplicates_across_groups = true, -- whether to consider duplicate paths in different groups as duplicates
             persist_buffer_sort = true, -- whether or not custom sorted buffers should persist

--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -149,7 +149,7 @@ The available configuration are:
             show_buffer_icons = true | false, -- disable filetype icons for buffers
             show_buffer_close_icons = true | false,
             show_close_icon = true | false,
-            show_tab_indicators = true | false | "always", -- shows tab indicators ('always' will show tab indicators even if there is only 1)
+            show_tab_indicators = true | false | "always", -- shows tab indicators ('always' will show tab indicators even if there is only 1 tab)
             show_duplicate_prefix = true | false, -- whether to show duplicate buffer prefix
             duplicates_across_groups = true, -- whether to consider duplicate paths in different groups as duplicates
             persist_buffer_sort = true, -- whether or not custom sorted buffers should persist

--- a/lua/bufferline/types.lua
+++ b/lua/bufferline/types.lua
@@ -49,7 +49,7 @@
 ---@field public show_buffer_default_icon? boolean
 ---@field public get_element_icon? fun(opts: bufferline.IconFetcherOpts): string?, string?
 ---@field public show_close_icon? boolean
----@field public show_tab_indicators? boolean
+---@field public show_tab_indicators? boolean | '"always"'-
 ---@field public show_duplicate_prefix? boolean
 ---@field public duplicates_across_groups? boolean
 ---@field public enforce_regular_tabs? boolean

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -446,8 +446,9 @@ end
 ---@return integer
 local function get_tab_indicator(tab_indicators, options)
   local items, length = {}, 0
-  if not options.show_tab_indicators then return items, length end
-  if not (options.show_tab_indicators == "always") and #tab_indicators <= 1 then return items, length end
+  if not options.show_tab_indicators or (not (options.show_tab_indicators == "always") and #tab_indicators <= 1) then
+    return items, length
+  end
   for _, tab in ipairs(tab_indicators) do
     local component = tab.component
     table.insert(items, component)

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -446,7 +446,8 @@ end
 ---@return integer
 local function get_tab_indicator(tab_indicators, options)
   local items, length = {}, 0
-  if not options.show_tab_indicators or #tab_indicators <= 1 then return items, length end
+  if not options.show_tab_indicators then return items, length end
+  if not (options.show_tab_indicators == "always") and #tab_indicators <= 1 then return items, length end
   for _, tab in ipairs(tab_indicators) do
     local component = tab.component
     table.insert(items, component)


### PR DESCRIPTION
Its all in the title, with this PR, users can set `show_tab_indicators` to true for the current true behavior (shows tab indicators when there are more than one), false for the current false behavior (never shows tab indicators) or "always" to always show tab indicators, even when there is only one tab.