### PR TITLE
Allows user defined separators to be used like slope/slant

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -156,7 +156,10 @@ The available configuration are:
             move_wraps_at_ends = false, -- whether or not the move command "wraps" at the first or last position
             -- can also be a table containing 2 custom separators
             -- [focused and unfocused]. eg: { '|', '|' }
-            separator_style = "slant" | "slope" | "thick" | "thin" | { 'any', 'any' },
+            separator_style = "slant" | "slope" | "thick" | "thin" | { 'any', 'any', 'always?'}, -- when using custom separators, include 'always' as the third item
+            -- in the table to apply separators to *every* buffer, like "slant"/"slope".
+            -- The default behavior is to share separators between buffers
+            -- for thick, thin and custom separators
             enforce_regular_tabs = false | true,
             always_show_bufferline = true | false,
             auto_toggle_bufferline = true | false,

--- a/lua/bufferline/types.lua
+++ b/lua/bufferline/types.lua
@@ -38,7 +38,7 @@
 ---@field public indicator? bufferline.Indicator
 ---@field public left_trunc_marker? string
 ---@field public right_trunc_marker? string
----@field public separator_style? string | {[1]: string, [2]: string}
+---@field public separator_style? string | {[1]: string, [2]: string, [3]: string}
 ---@field public name_formatter? (fun(path: string):string)?
 ---@field public tab_size? number
 ---@field public truncate_names? boolean

--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -251,10 +251,16 @@ end
 --- @param focused boolean
 --- @param style table | string
 local function get_separator(focused, style)
-  if type(style) == "table" then return focused and style[1] or style[2] end
+  if type(style) == "table" then
+    if style[3] == "always" then
+      return style[1], style[2]
+    else
+      return focused and style[1] or style[2]
+    end
+  end
   ---@diagnostic disable-next-line: undefined-field
   local chars = sep_chars[style] or sep_chars.thin
-  if is_slant(style) then return chars[1], chars[2] end
+  if type(style) == "string" and is_slant(style) then return chars[1], chars[2] end
   return focused and chars[1] or chars[2]
 end
 
@@ -341,7 +347,8 @@ local function add_separators(context)
   local style = options.separator_style
   local focused = context.tab:current() or context.tab:visible()
   local right_sep, left_sep = get_separator(focused, style)
-  local sep_hl = is_slant(style) and context.current_highlights.separator or hl.separator.hl_group
+  local sep_hl = (is_slant(style) or (style[3] == "always")) and context.current_highlights.separator
+    or hl.separator.hl_group
 
   local left_separator = left_sep and { text = left_sep, highlight = sep_hl } or nil
   local right_separator = { text = right_sep, highlight = sep_hl }


### PR DESCRIPTION
Currently, slope and slant (and their padded variants) are the only types of indicators that are privileged enough to be put at the start AND end of a buffer. Thin, thick and user-defined separators are shared between buffers.

This adds an "always" option - by setting the 3rd entry of the separators table to "always", users can elect to apply their custom selectors to every buffer individually, instead of having separators be shared between buffers