### PR TITLE
fix(diagnostics): limit amount of diagnostics processed improving performance

### DIFF
--- a/lua/bufferline/diagnostics.lua
+++ b/lua/bufferline/diagnostics.lua
@@ -79,11 +79,32 @@ end
 local get_diagnostics = {
   nvim_lsp = function()
     local results = {}
-    local diagnostics = vim.diagnostic.get()
-    for _, d in pairs(diagnostics) do
-      if diagnostic_is_enabled(d) then
-        if not results[d.bufnr] then results[d.bufnr] = {} end
-        table.insert(results[d.bufnr], d)
+
+    -- skip buffers opened by LSP, use only loaded ones
+    local current_buffers = vim.api.nvim_list_bufs()
+    local loaded_buffers = {}
+    for _, bufnr in ipairs(current_buffers) do
+      if vim.api.nvim_buf_is_loaded(bufnr) then table.insert(loaded_buffers, bufnr) end
+    end
+
+    for _, bufnr in pairs(loaded_buffers) do
+      local diagnostics_count = vim.diagnostic.count(bufnr)
+      diagnostics_count = 0
+        + (diagnostics_count[vim.diagnostic.severity.ERROR] or 0)
+        + (diagnostics_count[vim.diagnostic.severity.WARN] or 0)
+        + (diagnostics_count[vim.diagnostic.severity.INFO] or 0)
+        + (diagnostics_count[vim.diagnostic.severity.HINT] or 0)
+
+      -- A safeguard to skip processing too many diagnostics altogether per given buffer
+      if diagnostics_count < 1024 then
+        local diagnostics = vim.diagnostic.get(bufnr)
+        for _ = 1, #diagnostics do
+          local d = diagnostics[_]
+          if diagnostic_is_enabled(d) then
+            if not results[d.bufnr] then results[d.bufnr] = {} end
+            table.insert(results[bufnr], d)
+          end
+        end
       end
     end
     return results


### PR DESCRIPTION
https://github.com/akinsho/bufferline.nvim/blob/655133c3b4c3e5e05ec549b9f8cc2894ac6f51b3/lua/bufferline/diagnostics.lua?plain=1#L80-L90

The above chunk of code gets constantly evaluated in a loop with `diagnostics.get(options)`  fetching multiple times the same array with evergrowing number of diagnostics that get added by LSP over time.
The table `diagnostics` is evaluated by `for _, d in pairs(diagnostics)`  loop multiple times though diagnostics remain the same. This results in a degraded performance.

### Replicate the issue
I've discovered accidentally a massive drop in performance while configuring lua-language-server (LLS) for nvim plugin project.

Checkout a small bash script down below that automatically sets up a project that replicates the issue. It opens `commands.lua` file which gets over 2500+ diagnostics (to check this out, you can debug the above chunk of code).

Make sure that LLS is installed and configured for your nvim, and   
you have the latest `bufferline.nvim` and the following config setup:
```lua
	config = {}
	config.options.diagnostics  = "nvim_lsp"
	config.options.diagnostics_update_on_event = true
	bufferline.setup(config)

```


<details><summary>REPLICATE.sh</summary>

```sh
#!/usr/bin/env -S bash 

pushd $(mktemp -d -p /tmp project-XXXXXXXXX)
test -d ./lua/test/ && echo "exists: ${_}" || mkdir -vp $_
test -s ./lua/test/commands.lua || {
cat <<EOL > ./lua/test/commands.lua
vim.api.nvim_del_user_command("string")
vim.api.nvim_create_user_command() 
---@type vim.api.keyset.create_user_command.command_args
local someVar
EOL
}


test -s .luarc.json || {
cat <<EOL > .luarc.json
{
	"\$schema": "https://raw.githubusercontent.com/sumneko/vscode-lua/master/setting/schema.json",
	"runtime": {
		"version": "LuaJIT",
		"path": [
		]
	},
	"workspace": {
		"library": [
		"/usr/local/share/nvim/runtime/lua/vim/_meta.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/api.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/api_keysets.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/api_keysets_extra.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/base64.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/builtin.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/builtin_types.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/diff.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/lpeg.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/regex.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/vimfn.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/vvars.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_meta/vvars_extra.lua",
		"/usr/local/share/nvim/runtime/lua/vim/_options.lua"
		],
		"checkThirdParty": false,
		"userThirdParty": []
	},
	"diagnostics": {
		"globals": [
		"vim"
		],
		"disable": [
		"unused-local",
		"unused-vararg"
		]
	},
	"format.enable": false
}
EOL

}

echo "${0}: running editor ${EDITOR}"
${EDITOR:-nvim} -p ./lua/test/commands.lua /usr/local/share/nvim/runtime/lua/vim/_meta/api_keysets.lua

```
</details> 

### Workaround
Just disable diagnostics in 
```lua
	config.options.diagnostics = false
	bufferline.setup(config)

```

### Related
* https://github.com/akinsho/bufferline.nvim/pull/932