### PR TITLE
fix(ui): mirror left and right trunk marker

### DIFF
--- a/lua/bufferline/ui.lua
+++ b/lua/bufferline/ui.lua
@@ -431,7 +431,21 @@ end
 ---@param icon_hl string
 ---@param count number
 ---@return bufferline.Segment[]?
-local function get_trunc_marker(trunc_icon, count_hl, icon_hl, count)
+local function get_left_trunc_marker(trunc_icon, count_hl, icon_hl, count)
+  if count > 0 then
+    return {
+      { highlight = icon_hl, text = padding .. trunc_icon },
+      { highlight = count_hl, text = padding .. count .. padding },
+    }
+  end
+end
+
+---@param trunc_icon string
+---@param count_hl string
+---@param icon_hl string
+---@param count number
+---@return bufferline.Segment[]?
+local function get_right_trunc_marker(trunc_icon, count_hl, icon_hl, count)
   if count > 0 then
     return {
       { highlight = count_hl, text = padding .. count .. padding },
@@ -678,8 +692,8 @@ function M.tabline(items, tab_indicators)
   })
 
   local marker_hl = hl.trunc_marker.hl_group
-  local left_marker = get_trunc_marker(left_trunc_icon, marker_hl, marker_hl, marker.left_count)
-  local right_marker = get_trunc_marker(right_trunc_icon, marker_hl, marker_hl, marker.right_count)
+  local left_marker = get_left_trunc_marker(left_trunc_icon, marker_hl, marker_hl, marker.left_count)
+  local right_marker = get_right_trunc_marker(right_trunc_icon, marker_hl, marker_hl, marker.right_count)
 
   local core = join(
     utils.merge_lists(


### PR DESCRIPTION
Small Ui improvement to mirror the left and right trunc marker and number.

Before:
<img width="962" alt="Screenshot 2025-05-08 at 20 27 56" src="https://github.com/user-attachments/assets/6b3cee9b-3f3b-4df3-8719-4b1860f0c7ee" />

After:
<img width="963" alt="Screenshot 2025-05-08 at 20 26 39" src="https://github.com/user-attachments/assets/c5069b78-7683-4dda-b6f1-e3092603e3f3" />
