### PR TITLE
feat(duplicates): add `default_duplicate_prefix` option

### DIFF
--- a/doc/bufferline.txt
+++ b/doc/bufferline.txt
@@ -151,6 +151,7 @@ The available configuration are:
             show_close_icon = true | false,
             show_tab_indicators = true | false,
             show_duplicate_prefix = true | false, -- whether to show duplicate buffer prefix
+            default_duplicate_prefix = "(duplicated) ", -- prefix added to buffers when there is no other way to differentiate them
             duplicates_across_groups = true, -- whether to consider duplicate paths in different groups as duplicates
             persist_buffer_sort = true, -- whether or not custom sorted buffers should persist
             move_wraps_at_ends = false, -- whether or not the move command "wraps" at the first or last position
@@ -661,8 +662,8 @@ this can also be mapped to something like
   nnoremap <silent> gD :BufferLinePickClose<CR>
 >
 
-You can configure the characters used for selecting buffers using the 
-`pick.alphabet` option. By default, both uppercase and lowercase 
+You can configure the characters used for selecting buffers using the
+`pick.alphabet` option. By default, both uppercase and lowercase
 alphanumeric characters are used.
 >lua
     options = {

--- a/lua/bufferline/config.lua
+++ b/lua/bufferline/config.lua
@@ -658,6 +658,7 @@ local function get_defaults()
     show_close_icon = true,
     show_tab_indicators = true,
     show_duplicate_prefix = true,
+    default_duplicate_prefix = "(duplicated) ",
     duplicates_across_groups = true,
     enforce_regular_tabs = false,
     always_show_bufferline = true,

--- a/lua/bufferline/models.lua
+++ b/lua/bufferline/models.lua
@@ -2,6 +2,7 @@ local lazy = require("bufferline.lazy")
 local utils = lazy.require("bufferline.utils") ---@module "bufferline.utils"
 local log = lazy.require("bufferline.utils.log") ---@module "bufferline.utils.log"
 local constants = lazy.require("bufferline.constants") ---@module "bufferline.constants"
+local config = lazy.require("bufferline.config") ---@module "bufferline.config"
 
 local M = {}
 
@@ -147,7 +148,7 @@ function Tabpage:visible() return api.nvim_get_current_tabpage() == self.id end
 --- @param formatter fun(string, number)
 --- @return string
 function Tabpage:ancestor(depth, formatter)
-  if self.duplicated == "element" then return "(duplicated) " end
+  if self.duplicated == "element" then return config.options.default_duplicate_prefix end
   return self:__ancestor(depth, formatter)
 end
 

--- a/lua/bufferline/types.lua
+++ b/lua/bufferline/types.lua
@@ -51,6 +51,7 @@
 ---@field public show_close_icon? boolean
 ---@field public show_tab_indicators? boolean
 ---@field public show_duplicate_prefix? boolean
+---@field public default_duplicate_prefix? string
 ---@field public duplicates_across_groups? boolean
 ---@field public enforce_regular_tabs? boolean
 ---@field public always_show_bufferline? boolean


### PR DESCRIPTION
Exposes a config option to change the default text of "(duplicated) " shown when buffers/tabpages have no other way to be differentiated. Addresses #998.

```lua
return {
  "akinsho/bufferline.nvim",
  opts = {
    options = {
      default_duplicate_prefix = "(duplicated) ",
    }
  }
}
