### PR TITLE
Added resession extension to persist tabpage names across sessions

### DIFF
--- a/lua/bufferline.lua
+++ b/lua/bufferline.lua
@@ -47,6 +47,9 @@ local M = {
   style_preset = config.STYLE_PRESETS,
 
   groups = groups,
+
+  ---@type fun(tabIndex: number): boolean
+  tab_filter = function(tabIndex) return true end
 }
 -----------------------------------------------------------------------------//
 
@@ -190,8 +193,10 @@ local function setup_diagnostic_handler(preferences)
   end
 end
 
+
 ---@param conf bufferline.UserConfig?
 function M.setup(conf)
+
   conf = conf or {}
   config.setup(conf)
   groups.setup(conf) -- Groups must be set up before the config is applied
@@ -204,6 +209,7 @@ function M.setup(conf)
   setup_diagnostic_handler(preferences)
   vim.o.tabline = "%!v:lua.nvim_bufferline()"
   toggle_bufferline()
+  M.tab_filter = config.options.tab_filter or M.tab_filter
 end
 
 return M

--- a/lua/bufferline/utils/init.lua
+++ b/lua/bufferline/utils/init.lua
@@ -37,6 +37,12 @@ function M.fold(callback, list, accum)
   return accum
 end
 
+---Strip whitespace from a string
+---@param str string
+function M.stripString(str)
+  return str:gsub("^%s*(.-)%s*$", "%1")
+end
+
 ---Variant of some that sums up the display size of characters
 ---@vararg string
 ---@return integer

--- a/lua/resession/extensions/bufferline.lua
+++ b/lua/resession/extensions/bufferline.lua
@@ -13,7 +13,6 @@ function M.on_save()
         function(comp) return comp.attr ~= nil end,
         components
       )[1]
-      print('Saving tab ' .. #tabNames+1 .. ' as ' .. titleComponent.text)
       tabNames[#tabNames+1] = titleComponent.text
   end
   return tabNames

--- a/lua/resession/extensions/bufferline.lua
+++ b/lua/resession/extensions/bufferline.lua
@@ -1,4 +1,5 @@
 local tabPages = require('bufferline.tabpages')
+local util = require('bufferline.utils')
 
 local M = {}
 
@@ -25,7 +26,7 @@ function M.on_load(tabNames)
   local tabIndex = vim.api.nvim_win_get_tabpage(0)
   for _, _ in ipairs(tabNames) do
     local tabName = tabNames[tabIndex]
-    tabPages.rename_tab(tabIndex, tabName)
+    tabPages.rename_tab(tabIndex, util.stripString(tabName))
     tabIndex = tabIndex+1
     if tabIndex > #tabNames then tabIndex = 1 end
     vim.cmd('tabnext')

--- a/lua/resession/extensions/bufferline.lua
+++ b/lua/resession/extensions/bufferline.lua
@@ -20,10 +20,11 @@ function M.on_save()
 end
 
 
-function M.on_load(tabNames)
+function M.on_post_load(tabNames)
 
   -- Start from the *current* tab index, and wraparound
-  local tabIndex = vim.api.nvim_win_get_tabpage(0)
+  local tabId = vim.api.nvim_win_get_tabpage(0)
+  local tabIndex = vim.api.nvim_tabpage_get_number(tabId)
   for _, _ in ipairs(tabNames) do
     local tabName = tabNames[tabIndex]
     tabPages.rename_tab(tabIndex, util.stripString(tabName))

--- a/lua/resession/extensions/bufferline.lua
+++ b/lua/resession/extensions/bufferline.lua
@@ -1,0 +1,29 @@
+local tabPages = require('bufferline.tabpages')
+
+local M = {}
+
+function M.on_save()
+  local tabs = tabPages.get()
+  local tabNames = {}
+  for tabIndex, componentData in ipairs(tabs) do
+    local components = componentData.component
+
+    -- a little gross, but this will work - see tabPages.lua:render()
+    local titleComponent = vim.tbl_filter(
+        function(comp) return comp.attr ~= nil end,
+        components
+      )[1]
+      tabNames[#tabNames+1] = titleComponent.text
+  end
+  return tabNames
+end
+
+
+function M.on_load(data)
+  for tabIndex, tabName in ipairs(data) do
+    tabPages.rename_tab(tabIndex, tabName)
+  end
+end
+
+return M
+

--- a/lua/resession/extensions/bufferline.lua
+++ b/lua/resession/extensions/bufferline.lua
@@ -4,17 +4,20 @@ local util = require('bufferline.utils')
 local M = {}
 
 function M.on_save()
+  local tabFilter = require('bufferline').tab_filter
   local tabs = tabPages.get()
   local tabNames = {}
   for tabIndex, componentData in ipairs(tabs) do
+    local isFiltered = tabFilter(tabIndex)
     local components = componentData.component
-
     -- a little gross, but this will work - see tabPages.lua:render()
     local titleComponent = vim.tbl_filter(
         function(comp) return comp.attr ~= nil end,
         components
       )[1]
-      tabNames[#tabNames+1] = titleComponent.text
+    local tabName 
+    if isFiltered then tabName = titleComponent.text else tabName = "DELETE" end
+    tabNames[#tabNames+1] = tabName
   end
   return tabNames
 end
@@ -27,10 +30,15 @@ function M.on_post_load(tabNames)
   local tabIndex = vim.api.nvim_tabpage_get_number(tabId)
   for _, _ in ipairs(tabNames) do
     local tabName = tabNames[tabIndex]
-    tabPages.rename_tab(tabIndex, util.stripString(tabName))
-    tabIndex = tabIndex+1
-    if tabIndex > #tabNames then tabIndex = 1 end
-    vim.cmd('tabnext')
+    if tabName == 'DELETE' then
+      tabIndex = tabIndex+1
+      vim.cmd('tabclose')
+    else 
+      tabPages.rename_tab(tabIndex, util.stripString(tabName))
+      tabIndex = tabIndex+1
+      if tabIndex > #tabNames then tabIndex = 1 end
+      vim.cmd('tabnext')
+    end
   end
 end
 

--- a/lua/resession/extensions/bufferline.lua
+++ b/lua/resession/extensions/bufferline.lua
@@ -13,15 +13,23 @@ function M.on_save()
         function(comp) return comp.attr ~= nil end,
         components
       )[1]
+      print('Saving tab ' .. #tabNames+1 .. ' as ' .. titleComponent.text)
       tabNames[#tabNames+1] = titleComponent.text
   end
   return tabNames
 end
 
 
-function M.on_load(data)
-  for tabIndex, tabName in ipairs(data) do
+function M.on_load(tabNames)
+
+  -- Start from the *current* tab index, and wraparound
+  local tabIndex = vim.api.nvim_win_get_tabpage(0)
+  for _, _ in ipairs(tabNames) do
+    local tabName = tabNames[tabIndex]
     tabPages.rename_tab(tabIndex, tabName)
+    tabIndex = tabIndex+1
+    if tabIndex > #tabNames then tabIndex = 1 end
+    vim.cmd('tabnext')
   end
 end
 


### PR DESCRIPTION
This feature adds a [resession.nvim extension](https://github.com/stevearc/resession.nvim/tree/master?tab=readme-ov-file#extensions).

To enable the extension in your resession.nvim config, simply add an entry for it in your resession configuration:

Lazy.nvim example:
```lua
-- lua/plugins/resession.lua
return {
  "stevearc/resession.nvim",
  lazy = false,
  dependencies = {
      "akinsho/bufferline.nvim",   
  },
  opts = {
    extensions = {
      bufferline = {}
    } 
  }
}
```

Now, when sessions are saved/loaded with resession.nvim, the bufferline tab-page names will persist.

Note: I put this together for the explicit purpose of better integrating bufferline with [scope.nvim](https://github.com/tiagovla/scope.nvim/tree/main). Bufferline works out of the box with scope.nvim in *almost* every way. Tabpages are persisted, as are the per-tab pseudo-bufferlists that scope.nvim uses. However, even though the tabpages' content gets persisted, all of the tabs are renamed to 1,2...N whenever reloading a session. With this very small addition to bufferline, the combined usage of scope.nvim, bufferline .nvim, and resession.nvim feels very nice.